### PR TITLE
v0.4.0: Contract Signing & Integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-28
+
+### Added
+
+- **`mcpdiff sign` command** — Sign a snapshot with an Ed25519 or RSA private key. Produces a detached `.mcpc.sig` file alongside the snapshot. Verifies the content hash before signing to prevent signing corrupted files.
+- **`mcpdiff verify` command** — Verify a snapshot's detached signature using a public key. Performs three checks: content hash integrity, hash binding, and cryptographic signature verification.
+- **`mcpdiff verify-hash` command** — Quick integrity check: recomputes the content hash and compares to the stored value. No keys needed. Supports `--format json` for structured output.
+- **`--verify-signature` flag on `mcpdiff ci`** — Require a valid signature on the baseline snapshot before diffing. Prevents baseline tampering in CI pipelines.
+- **`--signature-key` option on `mcpdiff ci`** — Path to the public key for signature verification. Falls back to `MCP_SIGNATURE_KEY` environment variable (accepts PEM content or file path).
+- **GitHub Action `verify-signature` and `signature-key` inputs** — Enable baseline signature verification in the GitHub Action.
+
+### Core Library
+
+- `signContentHash()` — Sign a content hash with a private key, returning a `DetachedSignature`.
+- `verifySignature()` — Verify a snapshot against a detached signature and public key.
+- `verifyContentHash()` — Recompute and compare a snapshot's content hash.
+- `detectKeyAlgorithm()` — Auto-detect Ed25519 or RSA from a PEM key.
+- `parseSignatureFile()` — Parse and validate a `.mcpc.sig` JSON file.
+- `DetachedSignature`, `SignatureAlgorithm`, `VerifySignatureResult`, `VerifyHashResult` types.
+- `SIGNATURE_VERSION` constant (`"1.0.0"`).
+
 ## [0.3.0] - 2026-03-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-03-18
+
+### Added
+
+- **`mcpdiff watch` command** — Watch for file changes and re-diff against a baseline on every change. Configurable debounce, watch paths, and ignore patterns.
+- **Live diff (`--live` flag)** — Diff a baseline against a live server directly with `mcpdiff diff baseline.mcpc.json --live --command "node server.js"`, without capturing a separate snapshot file.
+- **Webhook support (`--webhook` flag)** — POST diff results to a URL on `diff`, `ci`, and `watch` commands. Sends a structured `WebhookPayload` with event type, source info, and full diff report.
+- **SSE transport (`--sse` flag)** — Use SSE transport instead of streamable-http when connecting via `--url`.
+- **Custom HTTP headers (`--header` flag)** — Pass custom headers as `"Key: Value"` pairs to HTTP/SSE transports. Repeatable.
+
+### Core Library
+
+- `createWatchConfig()` — Create a validated watch configuration with defaults.
+- `DEFAULT_WATCH_IGNORE_PATTERNS` — Default ignore patterns for watch mode (`node_modules`, `.git`, `dist`, `*.mcpc.json`).
+- `WatchConfig`, `WatchDiffEvent`, `CreateWatchConfigOptions` types.
+- `createWebhookPayload()` — Build a structured webhook payload from a diff report.
+- `WebhookPayload`, `WebhookSource`, `WebhookTrigger` types.
+
 ## [0.2.0] - 2026-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,6 +135,48 @@ mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js"
   --webhook https://example.com/hook
 ```
 
+### `mcpdiff sign`
+
+Signs a snapshot with a private key, producing a detached `.mcpc.sig` file.
+
+```bash
+# Sign with Ed25519
+mcpdiff sign contracts/baseline.mcpc.json --key ./private.pem
+
+# Sign with RSA
+mcpdiff sign contracts/baseline.mcpc.json --key ./rsa-private.pem
+
+# Write signature to a custom path
+mcpdiff sign snapshot.mcpc.json --key ./private.pem -o custom/path.mcpc.sig
+```
+
+The sign command verifies the content hash before signing — it will refuse to sign a snapshot whose content has been tampered with.
+
+### `mcpdiff verify`
+
+Verifies a snapshot's signature using a public key.
+
+```bash
+# Verify (auto-discovers .mcpc.sig file next to the snapshot)
+mcpdiff verify contracts/baseline.mcpc.json --key ./public.pem
+
+# Explicit signature path
+mcpdiff verify snapshot.mcpc.json --key ./public.pem --signature custom/path.mcpc.sig
+```
+
+Performs three checks: content hash integrity, hash binding (signature matches this snapshot), and cryptographic verification. Exit code 0 on success, 1 on failure.
+
+### `mcpdiff verify-hash`
+
+Quick integrity check — recomputes the content hash and compares to the stored value. No keys needed.
+
+```bash
+mcpdiff verify-hash snapshot.mcpc.json
+
+# JSON output
+mcpdiff verify-hash snapshot.mcpc.json --format json
+```
+
 ### `mcpdiff inspect`
 
 Summarizes a snapshot file.
@@ -197,6 +239,9 @@ jobs:
           fail-on: breaking        # or "warning" / "safe"
           comment-on-pr: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: verify baseline signature before diffing
+          verify-signature: true
+          signature-key: ${{ secrets.MCP_PUBLIC_KEY }}
 ```
 
 **Outputs:** `has-changes`, `has-breaking`, `summary`, `exit-code` — use them in subsequent steps.
@@ -216,6 +261,14 @@ jobs:
       - uses: actions/checkout@v4
       - run: npm install -g @mcp-contracts/cli
       - run: mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node dist/index.js"
+
+      # Or with signature verification
+      - run: >
+          mcpdiff ci
+          --baseline contracts/baseline.mcpc.json
+          --command "node dist/index.js"
+          --verify-signature
+          --signature-key ./public.pem
 ```
 
 The `ci` command auto-detects the CI environment and selects the right output format (markdown for GitHub Actions, JSON otherwise). It also writes to `GITHUB_STEP_SUMMARY` automatically.

--- a/README.md
+++ b/README.md
@@ -68,11 +68,17 @@ Compares two snapshots and classifies every change as breaking, warning, or safe
 ```bash
 mcpdiff diff before.mcpc.json after.mcpc.json
 
+# Diff a baseline against a live server
+mcpdiff diff baseline.mcpc.json --live --command "node server.js"
+
 # Fail CI on warnings too (stricter)
 mcpdiff diff before.mcpc.json after.mcpc.json --fail-on warning
 
 # Output as JSON for programmatic use
 mcpdiff diff before.mcpc.json after.mcpc.json --format json
+
+# Send results to a webhook
+mcpdiff diff before.mcpc.json after.mcpc.json --webhook https://example.com/hook
 ```
 
 **Exit codes:** `0` = no breaking changes, `1` = breaking changes detected, `2` = error.
@@ -106,9 +112,28 @@ mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --
 
 # Only show breaking changes
 mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --severity breaking
+
+# Send results to a webhook
+mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --webhook https://example.com/hook
 ```
 
 Auto-detects CI environments (GitHub Actions, GitLab CI, CircleCI) and selects the appropriate output format. Writes to `GITHUB_STEP_SUMMARY` when running in GitHub Actions.
+
+### `mcpdiff watch`
+
+Watch for file changes and re-diff against a baseline on every change. Useful during development.
+
+```bash
+mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js"
+
+# Watch specific paths with custom debounce
+mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js" \
+  --watch-paths src lib --debounce 1000
+
+# Send diffs to a webhook on each cycle
+mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js" \
+  --webhook https://example.com/hook
+```
 
 ### `mcpdiff inspect`
 
@@ -119,6 +144,30 @@ mcpdiff inspect snapshot.mcpc.json
 mcpdiff inspect snapshot.mcpc.json --tools
 mcpdiff inspect snapshot.mcpc.json --schema create_contact
 ```
+
+## Transport Options
+
+All commands that connect to a live server accept these transport options:
+
+```bash
+# SSE transport (instead of default streamable-http)
+mcpdiff snapshot --url http://localhost:3000/sse --sse -o snapshot.mcpc.json
+
+# Custom HTTP headers (repeatable)
+mcpdiff snapshot --url http://localhost:3000/mcp \
+  --header "Authorization: Bearer token" \
+  --header "X-Custom: value" \
+  -o snapshot.mcpc.json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--command <cmd>` | Server command to run via stdio transport |
+| `--url <url>` | Server URL for streamable-http or SSE transport |
+| `--sse` | Use SSE transport instead of streamable-http (requires `--url`) |
+| `--header <header...>` | Custom HTTP headers as `"Key: Value"` (repeatable) |
+| `--config <path>` | Path to `mcp.json` config file |
+| `--server <name>` | Server name from config file |
 
 ## Why Description Changes are Warnings
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -354,14 +354,81 @@ interface DiffReport {
 
 ---
 
-## 5. Future Features (Not for v0.1)
+## 5. Contract Signing & Integrity
 
-These are planned but should NOT be implemented in the initial release. Listed here for context.
+### 5.1 Detached Signature Format (`.mcpc.sig`)
 
-- **Contract signing** — Cryptographic signing of snapshots for integrity verification.
+A detached signature file is a JSON file stored alongside the `.mcpc.json` snapshot. It covers the `contentHash` field, which itself is a SHA-256 of the canonical tools/resources/prompts content.
+
+```typescript
+interface DetachedSignature {
+  /** Format version for the signature file. Currently "1.0.0". */
+  signatureVersion: "1.0.0";
+  /** The cryptographic algorithm used: "Ed25519" or "RSA-PSS-SHA256". */
+  algorithm: "Ed25519" | "RSA-PSS-SHA256";
+  /** The contentHash that was signed (binding reference to the snapshot). */
+  contentHash: string;
+  /** Base64-encoded signature bytes. */
+  signature: string;
+  /** ISO 8601 timestamp of when the signature was created. */
+  signedAt: string;
+}
+```
+
+**File naming convention:** Replace `.mcpc.json` with `.mcpc.sig` (e.g., `baseline.mcpc.json` → `baseline.mcpc.sig`).
+
+### 5.2 Supported Algorithms
+
+| Algorithm | Key Type | Signature | Padding |
+|-----------|----------|-----------|---------|
+| `Ed25519` | Ed25519 | `crypto.sign(null, data, key)` | N/A |
+| `RSA-PSS-SHA256` | RSA (2048+ bits) | `crypto.sign("sha256", data, key)` | RSA_PKCS1_PSS_PADDING |
+
+Key types are auto-detected from the PEM file using `crypto.createPrivateKey()` / `crypto.createPublicKey()`.
+
+### 5.3 Signing Process
+
+1. Read the snapshot file and verify its `contentHash` matches the recomputed hash. Refuse to sign if mismatched.
+2. Detect the algorithm from the private key PEM.
+3. Sign the `contentHash` string (UTF-8 encoded) with the private key.
+4. Write the `DetachedSignature` as a `.mcpc.sig` JSON file.
+
+### 5.4 Verification Process
+
+Verification performs three checks in order:
+
+1. **Content hash integrity** — Recompute the hash from `tools`, `resources`, `prompts` and compare to `snapshot.contentHash`. Fails if the snapshot content was tampered.
+2. **Hash binding** — Compare `snapshot.contentHash` to `signature.contentHash`. Fails if the signature was created for a different snapshot.
+3. **Cryptographic verification** — Verify the signature bytes against the public key. Fails if signed by a different key or if signature bytes were tampered.
+
+### 5.5 Content Hash Verification
+
+`mcpdiff verify-hash` provides a quick integrity check without keys:
+
+1. Recompute the content hash from the snapshot's `tools`, `resources`, and `prompts`.
+2. Compare to the stored `contentHash` field.
+3. Exit 0 if they match, exit 1 if they don't.
+
+### 5.6 CLI Commands
+
+```
+mcpdiff sign <snapshot> --key <private-key-path>
+mcpdiff verify <snapshot> --key <public-key-path> [--signature <sig-path>]
+mcpdiff verify-hash <snapshot>
+```
+
+### 5.7 CI Integration
+
+The `ci` command accepts `--verify-signature` and `--signature-key <path>` to verify the baseline signature before diffing. Falls back to `MCP_SIGNATURE_KEY` environment variable (PEM content or file path).
+
+The GitHub Action accepts `verify-signature` and `signature-key` inputs for the same purpose.
+
+---
+
+## 6. Future Features
+
+These are planned but not yet implemented. Listed here for context.
+
 - **Transparency log** — Append-only history of contract versions.
-- **Live diff** — `mcpdiff diff --live <url> snapshot.mcpc.json` to diff a running server against a pinned contract.
-- **Watch mode** — `mcpdiff watch --command "node server.js"` to re-snapshot on file changes and report diffs.
 - **Contract testing** — Generate and run test suites from contracts (`@mcp-contracts/test` package).
-- **GitHub Action** — `@mcp-contracts/diff-action` for CI integration.
 - **Registry integration** — Publish contracts alongside servers in the MCP Registry.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,6 +16,33 @@ Or run directly with npx:
 npx @mcp-contracts/cli snapshot --command "node server.js" -o snapshot.mcpc.json
 ```
 
+## Global Options
+
+```
+--format <format>    Output format: terminal | json | markdown
+--no-color           Disable colored output
+-o, --output <path>  Output file path
+--quiet              Suppress non-essential output
+--verbose            Show detailed information
+```
+
+## Transport Options
+
+Most commands accept transport options to connect to a live MCP server:
+
+```
+--command <cmd>       Server command to run via stdio transport
+--args <args...>      Arguments for the server command
+--url <url>           Server URL for streamable-http or SSE transport
+--sse                 Use SSE transport instead of streamable-http (requires --url)
+--header <header...>  Custom HTTP headers as "Key: Value" (repeatable)
+--config <path>       Path to mcp.json config file
+--server <name>       Server name from config file
+--env <pairs...>      Environment variables as KEY=VALUE pairs
+```
+
+Exactly one of `--command`, `--url`, or `--config` must be specified.
+
 ## Commands
 
 ### `mcpdiff snapshot`
@@ -29,6 +56,9 @@ mcpdiff snapshot --command "node server.js" -o snapshot.mcpc.json
 # Via HTTP transport
 mcpdiff snapshot --url http://localhost:3000/mcp -o snapshot.mcpc.json
 
+# Via SSE transport with custom headers
+mcpdiff snapshot --url http://localhost:3000/sse --sse --header "Authorization: Bearer token" -o snapshot.mcpc.json
+
 # From an mcp.json config file
 mcpdiff snapshot --config ./mcp.json --server my-server -o snapshot.mcpc.json
 ```
@@ -40,14 +70,99 @@ Compares two snapshots and classifies every change as breaking, warning, or safe
 ```bash
 mcpdiff diff before.mcpc.json after.mcpc.json
 
+# Diff a baseline against a live server
+mcpdiff diff baseline.mcpc.json --live --command "node server.js"
+
 # Fail CI on warnings too
 mcpdiff diff before.mcpc.json after.mcpc.json --fail-on warning
 
 # Output as JSON
 mcpdiff diff before.mcpc.json after.mcpc.json --format json
+
+# Send results to a webhook
+mcpdiff diff before.mcpc.json after.mcpc.json --webhook https://example.com/hook
+```
+
+**Options:**
+
+```
+--live               Diff baseline against a live server instead of a file
+--severity <level>   Minimum severity to display: safe | warning | breaking (default: "safe")
+--fail-on <level>    Exit code 1 threshold: safe | warning | breaking (default: "breaking")
+--webhook <url>      POST diff results to a webhook URL
 ```
 
 **Exit codes:** `0` = no breaking changes, `1` = breaking changes detected, `2` = error.
+
+### `mcpdiff baseline`
+
+Manage contract baselines — capture and verify snapshots against a committed baseline.
+
+```bash
+# Capture a baseline (default: contracts/baseline.mcpc.json)
+mcpdiff baseline update --command "node server.js"
+
+# Write to a custom path
+mcpdiff -o custom/path.mcpc.json baseline update --command "node server.js"
+
+# Verify the server still matches the baseline
+mcpdiff baseline verify --command "node server.js"
+mcpdiff baseline verify --baseline custom/path.mcpc.json --url http://localhost:3000/mcp
+```
+
+### `mcpdiff ci`
+
+All-in-one CI command: captures a snapshot, diffs against a baseline, outputs the report, and sets the exit code. Auto-detects CI environments (GitHub Actions, GitLab CI, CircleCI).
+
+```bash
+mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js"
+
+# Fail on warnings too
+mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --fail-on warning
+
+# Only show breaking changes
+mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --severity breaking
+
+# Send results to a webhook
+mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --webhook https://example.com/hook
+```
+
+**Options:**
+
+```
+--baseline <path>    Path to baseline snapshot (required)
+--fail-on <level>    Severity threshold for exit code 1 (default: "breaking")
+--severity <level>   Minimum severity to display (default: "safe")
+--webhook <url>      POST diff results to a webhook URL
+```
+
+### `mcpdiff watch`
+
+Watch for file changes and re-diff against a baseline on every change. Useful during development.
+
+```bash
+mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js"
+
+# Watch specific paths with custom debounce
+mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js" \
+  --watch-paths src lib --debounce 1000
+
+# Send diffs to a webhook on each cycle
+mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js" \
+  --webhook https://example.com/hook
+```
+
+**Options:**
+
+```
+--baseline <path>         Path to baseline snapshot (required)
+--watch-paths <paths...>  Paths to watch for changes (default: ["."])
+--debounce <ms>           Debounce interval in milliseconds (default: 500)
+--severity <level>        Minimum severity to display (default: "safe")
+--fail-on <level>         Severity threshold (default: "breaking")
+--webhook <url>           POST diffs on each cycle
+--clear                   Clear screen between diffs (auto-enabled if stdout is TTY)
+```
 
 ### `mcpdiff inspect`
 
@@ -69,10 +184,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
       - run: npm install -g @mcp-contracts/cli
-      - run: mcpdiff snapshot --command "node dist/index.js" -o current.mcpc.json
-      - run: mcpdiff diff contracts/baseline.mcpc.json current.mcpc.json
+      - run: mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node dist/index.js"
 ```
 ---
 *mcp-contracts is an open-source project (MIT license). It's community tooling for the MCP ecosystem, not affiliated with Anthropic or the MCP project. Contributions and feedback are welcome.*

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-contracts/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CLI tool for capturing and diffing MCP tool schemas",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -49,7 +49,7 @@ describe("integration: CLI", () => {
     it("exits 0 and prints version", async () => {
       const { stdout, exitCode } = await runCli("--version");
       expect(exitCode).toBe(0);
-      expect(stdout.trim()).toBe("0.3.0");
+      expect(stdout.trim()).toBe("0.4.0");
     });
   });
 

--- a/packages/cli/src/commands/ci.ts
+++ b/packages/cli/src/commands/ci.ts
@@ -1,12 +1,14 @@
-import { appendFileSync } from "node:fs";
-import type { Severity } from "@mcp-contracts/core";
+import { appendFileSync, readFileSync } from "node:fs";
+import type { MCPContractSnapshot, Severity } from "@mcp-contracts/core";
 import {
   createWebhookPayload,
   diffSnapshots,
   formatJson,
   formatMarkdown,
   formatTerminal,
+  parseSignatureFile,
   SEVERITY_ORDER,
+  verifySignature,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
 import { detectCIEnvironment } from "../ci-env.js";
@@ -22,6 +24,7 @@ import {
 } from "../utils.js";
 import { sendWebhook } from "../webhook.js";
 import { captureSnapshot } from "./capture.js";
+import { deriveSignaturePath } from "./sign.js";
 
 const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
 
@@ -59,6 +62,8 @@ export function createCiCommand(): Command {
     .option("--fail-on <level>", "Severity threshold for exit code 1", "breaking")
     .option("--severity <level>", "Minimum severity to display", "safe")
     .option("--webhook <url>", "POST diff results to a webhook URL")
+    .option("--verify-signature", "Require valid signature on baseline before diffing")
+    .option("--signature-key <path>", "Path to public key for signature verification")
     .action(
       handleErrors(async (options: Record<string, unknown>) => {
         const rootOpts = getRootOpts(cmd);
@@ -71,6 +76,16 @@ export function createCiCommand(): Command {
         const failOn = parseSeverity(options["failOn"] as string, "--fail-on");
 
         const baseline = readSnapshotFile(options["baseline"] as string);
+
+        // Verify baseline signature if requested
+        if (options["verifySignature"] === true) {
+          verifyBaselineSignature(
+            baseline,
+            options["baseline"] as string,
+            options["signatureKey"] as string | undefined,
+            quiet,
+          );
+        }
 
         const transportOpts: TransportOptions = {
           command: options["command"] as string | undefined,
@@ -165,4 +180,80 @@ function getRootOpts(cmd: Command): Record<string, unknown> {
     current = current.parent;
   }
   return current.opts();
+}
+
+/**
+ * Verifies the baseline snapshot's signature before diffing.
+ *
+ * @param baseline - The parsed baseline snapshot.
+ * @param baselinePath - File path to the baseline (used to derive sig path).
+ * @param signatureKeyOption - The --signature-key option value, if provided.
+ * @param quiet - Whether to suppress non-essential output.
+ */
+function verifyBaselineSignature(
+  baseline: MCPContractSnapshot,
+  baselinePath: string,
+  signatureKeyOption: string | undefined,
+  quiet: boolean,
+): void {
+  const keyPem = resolveSignatureKey(signatureKeyOption);
+  const sigPath = deriveSignaturePath(baselinePath);
+
+  let sigJson: string;
+  try {
+    sigJson = readFileSync(sigPath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read baseline signature file "${sigPath}": ${message}`);
+  }
+
+  const sig = parseSignatureFile(sigJson);
+  const result = verifySignature(baseline, sig, keyPem);
+
+  if (!result.valid) {
+    process.stderr.write(`Baseline signature verification failed: ${result.error}\n`);
+    throw new CliExitError(2);
+  }
+
+  if (!quiet) {
+    process.stderr.write("Baseline signature verified\n");
+  }
+}
+
+/**
+ * Resolves the public key PEM for signature verification.
+ *
+ * Checks the `--signature-key` option first, then the `MCP_SIGNATURE_KEY`
+ * environment variable. The env var can contain PEM content directly
+ * (starts with "-----BEGIN") or a file path.
+ *
+ * @param optionValue - The --signature-key option value, if provided.
+ * @returns The PEM string for the public key.
+ */
+function resolveSignatureKey(optionValue: string | undefined): string {
+  if (optionValue) {
+    try {
+      return readFileSync(optionValue, "utf-8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to read signature key file "${optionValue}": ${message}`);
+    }
+  }
+
+  const envValue = process.env["MCP_SIGNATURE_KEY"];
+  if (envValue) {
+    if (envValue.startsWith("-----BEGIN")) {
+      return envValue;
+    }
+    try {
+      return readFileSync(envValue, "utf-8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to read key from MCP_SIGNATURE_KEY path "${envValue}": ${message}`);
+    }
+  }
+
+  throw new Error(
+    "--verify-signature requires --signature-key <path> or MCP_SIGNATURE_KEY environment variable",
+  );
 }

--- a/packages/cli/src/commands/sign.test.ts
+++ b/packages/cli/src/commands/sign.test.ts
@@ -1,0 +1,113 @@
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSignCommand } from "./sign.js";
+
+const FIXTURES_DIR = resolve(import.meta.dirname, "../../../core/src/__fixtures__");
+const V1_PATH = resolve(FIXTURES_DIR, "server-v1.mcpc.json");
+
+let ed25519PrivatePath: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcpdiff-sign-test-"));
+  const ed = generateKeyPairSync("ed25519");
+  ed25519PrivatePath = join(tmpDir, "private.pem");
+  writeFileSync(
+    ed25519PrivatePath,
+    ed.privateKey.export({ type: "pkcs8", format: "pem" }) as string,
+  );
+});
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file");
+  program.addCommand(createSignCommand());
+  return program;
+}
+
+describe("sign command", () => {
+  let stderrData: string;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    stderrData = "";
+    exitCode = undefined;
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("produces a .mcpc.sig file", async () => {
+    const sigPath = join(tmpDir, "server-v1.mcpc.sig");
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "sign",
+      V1_PATH,
+      "--key",
+      ed25519PrivatePath,
+      "-o",
+      sigPath,
+    ]);
+
+    const sig = JSON.parse(readFileSync(sigPath, "utf-8"));
+    expect(sig.signatureVersion).toBe("1.0.0");
+    expect(sig.algorithm).toBe("Ed25519");
+    expect(sig.signature).toBeTruthy();
+    expect(stderrData).toContain("Signature written to");
+  });
+
+  it("errors when key file is missing", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "sign",
+        V1_PATH,
+        "--key",
+        "/nonexistent/key.pem",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Failed to read key file");
+  });
+
+  it("errors on invalid snapshot file", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "sign",
+        "/nonexistent/snapshot.mcpc.json",
+        "--key",
+        ed25519PrivatePath,
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Failed to read snapshot file");
+  });
+});

--- a/packages/cli/src/commands/sign.test.ts
+++ b/packages/cli/src/commands/sign.test.ts
@@ -2,6 +2,8 @@ import { generateKeyPairSync } from "node:crypto";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import { computeContentHash } from "@mcp-contracts/core";
 import { Command } from "commander";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSignCommand } from "./sign.js";
@@ -10,6 +12,7 @@ const FIXTURES_DIR = resolve(import.meta.dirname, "../../../core/src/__fixtures_
 const V1_PATH = resolve(FIXTURES_DIR, "server-v1.mcpc.json");
 
 let ed25519PrivatePath: string;
+let validSnapshotPath: string;
 let tmpDir: string;
 
 beforeAll(() => {
@@ -20,6 +23,12 @@ beforeAll(() => {
     ed25519PrivatePath,
     ed.privateKey.export({ type: "pkcs8", format: "pem" }) as string,
   );
+
+  // Create a snapshot with a valid content hash
+  const snapshot = JSON.parse(readFileSync(V1_PATH, "utf-8")) as MCPContractSnapshot;
+  snapshot.contentHash = computeContentHash(snapshot.tools, snapshot.resources, snapshot.prompts);
+  validSnapshotPath = join(tmpDir, "valid.mcpc.json");
+  writeFileSync(validSnapshotPath, JSON.stringify(snapshot, null, 2));
 });
 
 function createProgram(): Command {
@@ -55,13 +64,13 @@ describe("sign command", () => {
   });
 
   it("produces a .mcpc.sig file", async () => {
-    const sigPath = join(tmpDir, "server-v1.mcpc.sig");
+    const sigPath = join(tmpDir, "valid.mcpc.sig");
     const program = createProgram();
     await program.parseAsync([
       "node",
       "mcpdiff",
       "sign",
-      V1_PATH,
+      validSnapshotPath,
       "--key",
       ed25519PrivatePath,
       "-o",
@@ -75,6 +84,18 @@ describe("sign command", () => {
     expect(stderrData).toContain("Signature written to");
   });
 
+  it("refuses to sign a snapshot with invalid content hash", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "sign", V1_PATH, "--key", ed25519PrivatePath]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Content hash mismatch");
+    expect(stderrData).toContain("Refusing to sign");
+  });
+
   it("errors when key file is missing", async () => {
     const program = createProgram();
     try {
@@ -82,7 +103,7 @@ describe("sign command", () => {
         "node",
         "mcpdiff",
         "sign",
-        V1_PATH,
+        validSnapshotPath,
         "--key",
         "/nonexistent/key.pem",
       ]);

--- a/packages/cli/src/commands/sign.ts
+++ b/packages/cli/src/commands/sign.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { signContentHash } from "@mcp-contracts/core";
+import { signContentHash, verifyContentHash } from "@mcp-contracts/core";
 import { Command } from "commander";
 import { handleErrors, readSnapshotFile, writeOutput } from "../utils.js";
 
@@ -36,6 +36,14 @@ export function createSignCommand(): Command {
           (rootOpts["output"] as string | undefined) ?? deriveSignaturePath(snapshotPath);
 
         const snapshot = readSnapshotFile(snapshotPath);
+
+        const hashCheck = verifyContentHash(snapshot);
+        if (!hashCheck.valid) {
+          throw new Error(
+            `Content hash mismatch: stored "${hashCheck.expected}" but recomputed "${hashCheck.actual}". ` +
+              "Refusing to sign a snapshot with an invalid content hash.",
+          );
+        }
 
         let keyPem: string;
         try {

--- a/packages/cli/src/commands/sign.ts
+++ b/packages/cli/src/commands/sign.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { signContentHash } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { handleErrors, readSnapshotFile, writeOutput } from "../utils.js";
+
+/**
+ * Derives the `.mcpc.sig` path from a snapshot file path.
+ *
+ * @param snapshotPath - Path to the `.mcpc.json` file.
+ * @returns The corresponding `.mcpc.sig` path.
+ */
+export function deriveSignaturePath(snapshotPath: string): string {
+  if (snapshotPath.endsWith(".mcpc.json")) {
+    return `${snapshotPath.slice(0, -".mcpc.json".length)}.mcpc.sig`;
+  }
+  return `${snapshotPath}.sig`;
+}
+
+/**
+ * Creates the `sign` subcommand for the mcpdiff CLI.
+ *
+ * Signs a snapshot's content hash with a private key and produces a detached
+ * `.mcpc.sig` file alongside the snapshot.
+ *
+ * @returns A Commander Command instance for the sign subcommand.
+ */
+export function createSignCommand(): Command {
+  const cmd = new Command("sign")
+    .description("Sign a snapshot with a private key")
+    .argument("<snapshot>", "Path to the snapshot file (.mcpc.json)")
+    .requiredOption("--key <path>", "Path to private key (PEM format, Ed25519 or RSA)")
+    .action(
+      handleErrors(async (snapshotPath: string, options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const outputPath =
+          (rootOpts["output"] as string | undefined) ?? deriveSignaturePath(snapshotPath);
+
+        const snapshot = readSnapshotFile(snapshotPath);
+
+        let keyPem: string;
+        try {
+          keyPem = readFileSync(options["key"] as string, "utf-8");
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw new Error(`Failed to read key file: ${message}`);
+        }
+
+        const sig = signContentHash(snapshot.contentHash, keyPem);
+        const json = JSON.stringify(sig, null, 2);
+
+        writeOutput(`${json}\n`, outputPath);
+        process.stderr.write(`Signature written to ${outputPath}\n`);
+      }),
+    );
+
+  return cmd;
+}
+
+/**
+ * Resolves the root program options from a deeply nested subcommand.
+ *
+ * @param cmd - The current Command instance.
+ * @returns The root program's parsed options.
+ */
+function getRootOpts(cmd: Command): Record<string, unknown> {
+  let current: Command | null = cmd;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}

--- a/packages/cli/src/commands/verify-hash.test.ts
+++ b/packages/cli/src/commands/verify-hash.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import { computeContentHash } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVerifyHashCommand } from "./verify-hash.js";
+
+const FIXTURES_DIR = resolve(import.meta.dirname, "../../../core/src/__fixtures__");
+const V1_PATH = resolve(FIXTURES_DIR, "server-v1.mcpc.json");
+
+let tmpDir: string;
+let validPath: string;
+let tamperedPath: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcpdiff-verify-hash-test-"));
+
+  // Create a snapshot with a valid content hash
+  const snapshot = JSON.parse(readFileSync(V1_PATH, "utf-8")) as MCPContractSnapshot;
+  snapshot.contentHash = computeContentHash(snapshot.tools, snapshot.resources, snapshot.prompts);
+  validPath = join(tmpDir, "valid.mcpc.json");
+  writeFileSync(validPath, JSON.stringify(snapshot, null, 2));
+
+  // Create a tampered snapshot where the contentHash no longer matches
+  const tampered = JSON.parse(readFileSync(V1_PATH, "utf-8")) as MCPContractSnapshot;
+  tampered.contentHash = computeContentHash(tampered.tools, tampered.resources, tampered.prompts);
+  const tool = tampered.tools["create_contact"];
+  if (tool) tool.description = "TAMPERED";
+  // contentHash now stale — no longer matches tools
+  tamperedPath = join(tmpDir, "tampered.mcpc.json");
+  writeFileSync(tamperedPath, JSON.stringify(tampered, null, 2));
+});
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file");
+  program.addCommand(createVerifyHashCommand());
+  return program;
+}
+
+describe("verify-hash command", () => {
+  let stdoutData: string;
+  let stderrData: string;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    stdoutData = "";
+    stderrData = "";
+    exitCode = undefined;
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutData += String(chunk);
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes for a valid snapshot (terminal)", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "verify-hash", validPath, "--format", "terminal"]);
+    expect(stdoutData).toContain("Content hash verified");
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("passes for a valid snapshot (json)", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "verify-hash", validPath, "--format", "json"]);
+    const output = JSON.parse(stdoutData);
+    expect(output.valid).toBe(true);
+    expect(output.expected).toBe(output.actual);
+  });
+
+  it("fails for a tampered snapshot (terminal)", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "verify-hash",
+        tamperedPath,
+        "--format",
+        "terminal",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+    expect(stderrData).toContain("Content hash mismatch");
+    expect(stderrData).toContain("Expected:");
+    expect(stderrData).toContain("Actual:");
+  });
+
+  it("fails for a tampered snapshot (json)", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "verify-hash",
+        tamperedPath,
+        "--format",
+        "json",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+    const output = JSON.parse(stdoutData);
+    expect(output.valid).toBe(false);
+    expect(output.expected).not.toBe(output.actual);
+  });
+
+  it("errors on invalid file path", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "verify-hash", "/nonexistent/path.json"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Failed to read snapshot file");
+  });
+});

--- a/packages/cli/src/commands/verify-hash.ts
+++ b/packages/cli/src/commands/verify-hash.ts
@@ -1,0 +1,63 @@
+import { verifyContentHash } from "@mcp-contracts/core";
+import { Command } from "commander";
+import {
+  CliExitError,
+  handleErrors,
+  readSnapshotFile,
+  resolveFormat,
+  writeOutput,
+} from "../utils.js";
+
+/**
+ * Creates the `verify-hash` subcommand for the mcpdiff CLI.
+ *
+ * Recomputes the content hash of a snapshot and compares it to the stored value.
+ * Quick integrity check without needing keys or signatures.
+ *
+ * @returns A Commander Command instance for the verify-hash subcommand.
+ */
+export function createVerifyHashCommand(): Command {
+  const cmd = new Command("verify-hash")
+    .description("Verify a snapshot's content hash integrity")
+    .argument("<snapshot>", "Path to the snapshot file (.mcpc.json)")
+    .action(
+      handleErrors(async (snapshotPath: string) => {
+        const rootOpts = getRootOpts(cmd);
+        const format = resolveFormat(rootOpts["format"] as string | undefined);
+        const outputPath = rootOpts["output"] as string | undefined;
+
+        const snapshot = readSnapshotFile(snapshotPath);
+        const result = verifyContentHash(snapshot);
+
+        if (format === "json") {
+          writeOutput(`${JSON.stringify(result, null, 2)}\n`, outputPath);
+        } else if (result.valid) {
+          writeOutput(`Content hash verified: ${result.actual}\n`, outputPath);
+        } else {
+          process.stderr.write(
+            `Content hash mismatch!\n  Expected: ${result.expected}\n  Actual:   ${result.actual}\n`,
+          );
+        }
+
+        if (!result.valid) {
+          throw new CliExitError(1);
+        }
+      }),
+    );
+
+  return cmd;
+}
+
+/**
+ * Resolves the root program options from a deeply nested subcommand.
+ *
+ * @param cmd - The current Command instance.
+ * @returns The root program's parsed options.
+ */
+function getRootOpts(cmd: Command): Record<string, unknown> {
+  let current: Command | null = cmd;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}

--- a/packages/cli/src/commands/verify.test.ts
+++ b/packages/cli/src/commands/verify.test.ts
@@ -1,0 +1,155 @@
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import { computeContentHash, signContentHash } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVerifyCommand } from "./verify.js";
+
+const FIXTURES_DIR = resolve(import.meta.dirname, "../../../core/src/__fixtures__");
+const V1_PATH = resolve(FIXTURES_DIR, "server-v1.mcpc.json");
+
+let ed25519PublicPath: string;
+let sigPath: string;
+let validSnapshotPath: string;
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcpdiff-verify-test-"));
+
+  const ed = generateKeyPairSync("ed25519");
+  const privatePem = ed.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  const publicPem = ed.publicKey.export({ type: "spki", format: "pem" }) as string;
+
+  ed25519PublicPath = join(tmpDir, "public.pem");
+  writeFileSync(ed25519PublicPath, publicPem);
+
+  // Create a snapshot with a valid content hash
+  const snapshot = JSON.parse(readFileSync(V1_PATH, "utf-8")) as MCPContractSnapshot;
+  snapshot.contentHash = computeContentHash(snapshot.tools, snapshot.resources, snapshot.prompts);
+  validSnapshotPath = join(tmpDir, "valid.mcpc.json");
+  writeFileSync(validSnapshotPath, JSON.stringify(snapshot, null, 2));
+
+  // Create a signature for the snapshot with correct hash
+  const sig = signContentHash(snapshot.contentHash, privatePem);
+  sigPath = join(tmpDir, "valid.mcpc.sig");
+  writeFileSync(sigPath, JSON.stringify(sig, null, 2));
+});
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file");
+  program.addCommand(createVerifyCommand());
+  return program;
+}
+
+describe("verify command", () => {
+  let stderrData: string;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    stderrData = "";
+    exitCode = undefined;
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("succeeds with valid signature and explicit --signature path", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "verify",
+      validSnapshotPath,
+      "--key",
+      ed25519PublicPath,
+      "--signature",
+      sigPath,
+    ]);
+    expect(stderrData).toContain("Signature verified");
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("fails with wrong public key", async () => {
+    const wrongEd = generateKeyPairSync("ed25519");
+    const wrongPublicPath = join(tmpDir, "wrong-public.pem");
+    writeFileSync(
+      wrongPublicPath,
+      wrongEd.publicKey.export({ type: "spki", format: "pem" }) as string,
+    );
+
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "verify",
+        validSnapshotPath,
+        "--key",
+        wrongPublicPath,
+        "--signature",
+        sigPath,
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+    expect(stderrData).toContain("Signature verification failed");
+  });
+
+  it("errors when signature file is missing", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "verify",
+        validSnapshotPath,
+        "--key",
+        ed25519PublicPath,
+        "--signature",
+        "/nonexistent/file.sig",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Failed to read signature file");
+  });
+
+  it("errors when key file is missing", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "verify",
+        validSnapshotPath,
+        "--key",
+        "/nonexistent/key.pem",
+        "--signature",
+        sigPath,
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Failed to read key file");
+  });
+});

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { parseSignatureFile, verifySignature } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { CliExitError, handleErrors, readSnapshotFile } from "../utils.js";
+import { deriveSignaturePath } from "./sign.js";
+
+/**
+ * Creates the `verify` subcommand for the mcpdiff CLI.
+ *
+ * Verifies a snapshot's detached signature using a public key.
+ * Checks content hash integrity, hash binding, and cryptographic signature.
+ *
+ * @returns A Commander Command instance for the verify subcommand.
+ */
+export function createVerifyCommand(): Command {
+  const cmd = new Command("verify")
+    .description("Verify a snapshot's signature with a public key")
+    .argument("<snapshot>", "Path to the snapshot file (.mcpc.json)")
+    .requiredOption("--key <path>", "Path to public key (PEM format, Ed25519 or RSA)")
+    .option("--signature <path>", "Path to signature file (default: <snapshot>.mcpc.sig)")
+    .action(
+      handleErrors(async (snapshotPath: string, options: Record<string, unknown>) => {
+        const snapshot = readSnapshotFile(snapshotPath);
+
+        let keyPem: string;
+        try {
+          keyPem = readFileSync(options["key"] as string, "utf-8");
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw new Error(`Failed to read key file: ${message}`);
+        }
+
+        const sigPath =
+          (options["signature"] as string | undefined) ?? deriveSignaturePath(snapshotPath);
+
+        let sigJson: string;
+        try {
+          sigJson = readFileSync(sigPath, "utf-8");
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          throw new Error(`Failed to read signature file "${sigPath}": ${message}`);
+        }
+
+        const sig = parseSignatureFile(sigJson);
+        const result = verifySignature(snapshot, sig, keyPem);
+
+        if (result.valid) {
+          process.stderr.write(`Signature verified: ${sig.algorithm} signature is valid\n`);
+          return;
+        }
+
+        process.stderr.write(`Signature verification failed: ${result.error}\n`);
+        throw new CliExitError(1);
+      }),
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,10 @@ import { createBaselineCommand } from "./commands/baseline.js";
 import { createCiCommand } from "./commands/ci.js";
 import { createDiffCommand } from "./commands/diff.js";
 import { createInspectCommand } from "./commands/inspect.js";
+import { createSignCommand } from "./commands/sign.js";
 import { createSnapshotCommand } from "./commands/snapshot.js";
+import { createVerifyCommand } from "./commands/verify.js";
+import { createVerifyHashCommand } from "./commands/verify-hash.js";
 import { createWatchCommand } from "./commands/watch.js";
 
 const program = new Command();
@@ -30,7 +33,10 @@ program.addCommand(createBaselineCommand());
 program.addCommand(createCiCommand());
 program.addCommand(createDiffCommand());
 program.addCommand(createInspectCommand());
+program.addCommand(createSignCommand());
 program.addCommand(createSnapshotCommand());
+program.addCommand(createVerifyCommand());
+program.addCommand(createVerifyHashCommand());
 program.addCommand(createWatchCommand());
 
 program.parse();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,7 +22,7 @@ const program = new Command();
 program
   .name("mcpdiff")
   .description("Capture, diff, and inspect MCP server tool schemas")
-  .version("0.3.0")
+  .version("0.4.0")
   .option("--format <format>", "Output format: terminal | json | markdown")
   .option("--no-color", "Disable colored output")
   .option("-o, --output <path>", "Output file path")

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -39,6 +39,47 @@ console.log(formatTerminal(report));
 - **`diffSnapshots(before, after, options?)`** — Compare two snapshots and classify every change by severity
 - **`computeContentHash(snapshot)`** — Generate a deterministic content hash for a snapshot
 - **`formatTerminal(report)`** / **`formatMarkdown(report)`** / **`formatJson(report)`** — Format a diff report for output
+- **`createWatchConfig(options?)`** — Create a validated watch configuration with defaults
+- **`createWebhookPayload(report, source)`** — Build a structured webhook payload from a diff report
+
+### Watch Types
+
+```typescript
+import {
+  createWatchConfig,
+  DEFAULT_WATCH_IGNORE_PATTERNS,
+  type WatchConfig,
+  type WatchDiffEvent,
+  type CreateWatchConfigOptions,
+} from "@mcp-contracts/core";
+
+// Create config with defaults
+const config = createWatchConfig({
+  debounceMs: 1000,
+  watchPaths: ["src"],
+});
+
+// config.ignorePatterns defaults to DEFAULT_WATCH_IGNORE_PATTERNS:
+// ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/*.mcpc.json"]
+```
+
+### Webhook Types
+
+```typescript
+import {
+  createWebhookPayload,
+  type WebhookPayload,
+  type WebhookSource,
+  type WebhookTrigger,
+} from "@mcp-contracts/core";
+
+const payload = createWebhookPayload(report, {
+  trigger: "ci",
+  baselinePath: "contracts/baseline.mcpc.json",
+  serverSource: "node server.js",
+});
+// → { event: "diff.completed", timestamp, source, report }
+```
 
 ### Change Classification
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-contracts/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Snapshot, diff, and classify MCP tool schema changes",
   "type": "module",
   "exports": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,20 @@ export type {
 export { SEVERITY_ORDER } from "./diff-types.js";
 export { formatJson, formatMarkdown, formatTerminal } from "./format.js";
 export { computeContentHash, sortKeys } from "./hash.js";
+export {
+  detectKeyAlgorithm,
+  parseSignatureFile,
+  signContentHash,
+  verifyContentHash,
+  verifySignature,
+} from "./sign.js";
+export type {
+  DetachedSignature,
+  SignatureAlgorithm,
+  VerifyHashResult,
+  VerifySignatureResult,
+} from "./sign-types.js";
+export { SIGNATURE_VERSION } from "./sign-types.js";
 export type {
   CreateSnapshotParams,
   RawPrompt,

--- a/packages/core/src/sign-types.test.ts
+++ b/packages/core/src/sign-types.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type {
+  DetachedSignature,
+  SignatureAlgorithm,
+  VerifyHashResult,
+  VerifySignatureResult,
+} from "./sign-types.js";
+import { SIGNATURE_VERSION } from "./sign-types.js";
+
+describe("SIGNATURE_VERSION", () => {
+  it("is 1.0.0", () => {
+    expect(SIGNATURE_VERSION).toBe("1.0.0");
+  });
+});
+
+describe("SignatureAlgorithm", () => {
+  it("accepts Ed25519 and RSA-PSS-SHA256", () => {
+    const ed: SignatureAlgorithm = "Ed25519";
+    const rsa: SignatureAlgorithm = "RSA-PSS-SHA256";
+    expect(ed).toBe("Ed25519");
+    expect(rsa).toBe("RSA-PSS-SHA256");
+  });
+});
+
+describe("DetachedSignature", () => {
+  it("can be constructed with all required fields", () => {
+    const sig: DetachedSignature = {
+      signatureVersion: "1.0.0",
+      algorithm: "Ed25519",
+      contentHash: "sha256:abc123",
+      signature: "base64data",
+      signedAt: "2026-03-28T00:00:00.000Z",
+    };
+    expect(sig.signatureVersion).toBe(SIGNATURE_VERSION);
+    expect(sig.algorithm).toBe("Ed25519");
+    expect(sig.contentHash).toBe("sha256:abc123");
+    expect(sig.signature).toBe("base64data");
+    expect(sig.signedAt).toBe("2026-03-28T00:00:00.000Z");
+  });
+});
+
+describe("VerifySignatureResult", () => {
+  it("represents a successful verification", () => {
+    const result: VerifySignatureResult = {
+      valid: true,
+      contentHashMatch: true,
+      signatureMatch: true,
+    };
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("represents a failed verification with error", () => {
+    const result: VerifySignatureResult = {
+      valid: false,
+      error: "Signature does not match",
+      contentHashMatch: true,
+      signatureMatch: false,
+    };
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Signature does not match");
+  });
+});
+
+describe("VerifyHashResult", () => {
+  it("represents a matching hash", () => {
+    const result: VerifyHashResult = {
+      valid: true,
+      expected: "sha256:abc",
+      actual: "sha256:abc",
+    };
+    expect(result.valid).toBe(true);
+    expect(result.expected).toBe(result.actual);
+  });
+
+  it("represents a mismatched hash", () => {
+    const result: VerifyHashResult = {
+      valid: false,
+      expected: "sha256:abc",
+      actual: "sha256:def",
+    };
+    expect(result.valid).toBe(false);
+    expect(result.expected).not.toBe(result.actual);
+  });
+});

--- a/packages/core/src/sign-types.ts
+++ b/packages/core/src/sign-types.ts
@@ -1,0 +1,54 @@
+/**
+ * Types for MCP contract snapshot signing and verification.
+ *
+ * Defines the detached signature format (`.mcpc.sig`) and result types
+ * for signing, signature verification, and content hash verification.
+ */
+
+/** Supported cryptographic algorithms for snapshot signing. */
+export type SignatureAlgorithm = "Ed25519" | "RSA-PSS-SHA256";
+
+/** The current signature file format version. */
+export const SIGNATURE_VERSION = "1.0.0" as const;
+
+/**
+ * A detached signature for an MCP contract snapshot.
+ *
+ * Stored as a `.mcpc.sig` JSON file alongside the `.mcpc.json` snapshot.
+ * The signature covers the `contentHash` field, which itself is a SHA-256
+ * of the canonical tools/resources/prompts content.
+ */
+export interface DetachedSignature {
+  /** Format version for the signature file. Currently "1.0.0". */
+  signatureVersion: typeof SIGNATURE_VERSION;
+  /** The cryptographic algorithm used to create the signature. */
+  algorithm: SignatureAlgorithm;
+  /** The contentHash that was signed (binding reference to the snapshot). */
+  contentHash: string;
+  /** Base64-encoded signature bytes. */
+  signature: string;
+  /** ISO 8601 timestamp of when the signature was created. */
+  signedAt: string;
+}
+
+/** Result of verifying a cryptographic signature against a snapshot. */
+export interface VerifySignatureResult {
+  /** Whether the overall verification passed. */
+  valid: boolean;
+  /** Human-readable error message if verification failed. */
+  error?: string;
+  /** Whether the recomputed content hash matches the snapshot's stored hash. */
+  contentHashMatch?: boolean;
+  /** Whether the cryptographic signature is valid. */
+  signatureMatch?: boolean;
+}
+
+/** Result of verifying a snapshot's content hash. */
+export interface VerifyHashResult {
+  /** Whether the stored hash matches the recomputed hash. */
+  valid: boolean;
+  /** The hash stored in the snapshot file. */
+  expected: string;
+  /** The hash recomputed from the snapshot's tools, resources, and prompts. */
+  actual: string;
+}

--- a/packages/core/src/sign.test.ts
+++ b/packages/core/src/sign.test.ts
@@ -1,0 +1,240 @@
+import { generateKeyPairSync } from "node:crypto";
+import { beforeAll, describe, expect, it } from "vitest";
+import { computeContentHash } from "./hash.js";
+import {
+  detectKeyAlgorithm,
+  parseSignatureFile,
+  signContentHash,
+  verifyContentHash,
+  verifySignature,
+} from "./sign.js";
+import type { DetachedSignature } from "./sign-types.js";
+import type { MCPContractSnapshot } from "./types.js";
+
+let ed25519Private: string;
+let ed25519Public: string;
+let rsaPrivate: string;
+let rsaPublic: string;
+
+beforeAll(() => {
+  const ed = generateKeyPairSync("ed25519");
+  ed25519Private = ed.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  ed25519Public = ed.publicKey.export({ type: "spki", format: "pem" }) as string;
+
+  const rsa = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  rsaPrivate = rsa.privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+  rsaPublic = rsa.publicKey.export({ type: "spki", format: "pem" }) as string;
+});
+
+function makeSnapshot(overrides?: Partial<MCPContractSnapshot>): MCPContractSnapshot {
+  const tools = { test: { description: "A test tool", inputSchema: { type: "object" } } };
+  const resources = {};
+  const prompts = {};
+  const contentHash = computeContentHash(tools, resources, prompts);
+  return {
+    snapshotVersion: "1.0.0",
+    capturedAt: "2026-03-28T00:00:00.000Z",
+    contentHash,
+    server: { name: "test", version: "1.0.0", protocolVersion: "2025-03-26", capabilities: {} },
+    capture: { transport: "stdio", tool: "mcpdiff/0.4.0" },
+    tools,
+    resources,
+    prompts,
+    ...overrides,
+  };
+}
+
+describe("detectKeyAlgorithm", () => {
+  it("detects Ed25519 private key", () => {
+    expect(detectKeyAlgorithm(ed25519Private)).toBe("Ed25519");
+  });
+
+  it("detects Ed25519 public key", () => {
+    expect(detectKeyAlgorithm(ed25519Public)).toBe("Ed25519");
+  });
+
+  it("detects RSA private key", () => {
+    expect(detectKeyAlgorithm(rsaPrivate)).toBe("RSA-PSS-SHA256");
+  });
+
+  it("detects RSA public key", () => {
+    expect(detectKeyAlgorithm(rsaPublic)).toBe("RSA-PSS-SHA256");
+  });
+
+  it("throws for invalid PEM", () => {
+    expect(() => detectKeyAlgorithm("not a key")).toThrow();
+  });
+});
+
+describe("signContentHash", () => {
+  it("produces a valid Ed25519 signature", () => {
+    const sig = signContentHash("sha256:abc123", ed25519Private);
+    expect(sig.signatureVersion).toBe("1.0.0");
+    expect(sig.algorithm).toBe("Ed25519");
+    expect(sig.contentHash).toBe("sha256:abc123");
+    expect(sig.signature).toBeTruthy();
+    expect(sig.signedAt).toBeTruthy();
+  });
+
+  it("produces a valid RSA signature", () => {
+    const sig = signContentHash("sha256:abc123", rsaPrivate);
+    expect(sig.algorithm).toBe("RSA-PSS-SHA256");
+    expect(sig.signature).toBeTruthy();
+  });
+
+  it("rejects invalid contentHash format", () => {
+    expect(() => signContentHash("md5:abc", ed25519Private)).toThrow("Invalid contentHash format");
+  });
+
+  it("rejects a public key as private key", () => {
+    expect(() => signContentHash("sha256:abc", ed25519Public)).toThrow();
+  });
+});
+
+describe("verifySignature", () => {
+  it("succeeds for valid Ed25519 round-trip", () => {
+    const snapshot = makeSnapshot();
+    const sig = signContentHash(snapshot.contentHash, ed25519Private);
+    const result = verifySignature(snapshot, sig, ed25519Public);
+    expect(result.valid).toBe(true);
+    expect(result.contentHashMatch).toBe(true);
+    expect(result.signatureMatch).toBe(true);
+  });
+
+  it("succeeds for valid RSA round-trip", () => {
+    const snapshot = makeSnapshot();
+    const sig = signContentHash(snapshot.contentHash, rsaPrivate);
+    const result = verifySignature(snapshot, sig, rsaPublic);
+    expect(result.valid).toBe(true);
+  });
+
+  it("fails when snapshot content is tampered", () => {
+    const snapshot = makeSnapshot();
+    const sig = signContentHash(snapshot.contentHash, ed25519Private);
+    // Tamper with tools after signing
+    const tool = snapshot.tools["test"];
+    if (tool) tool.description = "TAMPERED";
+    const result = verifySignature(snapshot, sig, ed25519Public);
+    expect(result.valid).toBe(false);
+    expect(result.contentHashMatch).toBe(false);
+    expect(result.error).toContain("Content hash mismatch");
+  });
+
+  it("fails when signature references a different hash", () => {
+    const snapshot = makeSnapshot();
+    const sig = signContentHash(snapshot.contentHash, ed25519Private);
+    // Change the stored hash to simulate a different snapshot
+    const tamperedSig: DetachedSignature = { ...sig, contentHash: "sha256:different" };
+    const result = verifySignature(snapshot, tamperedSig, ed25519Public);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Signature was created for hash");
+  });
+
+  it("fails with wrong public key", () => {
+    const snapshot = makeSnapshot();
+    const sig = signContentHash(snapshot.contentHash, ed25519Private);
+    // Use RSA public key to verify Ed25519 signature
+    const otherEd = generateKeyPairSync("ed25519");
+    const wrongPublic = otherEd.publicKey.export({ type: "spki", format: "pem" }) as string;
+    const result = verifySignature(snapshot, sig, wrongPublic);
+    expect(result.valid).toBe(false);
+    expect(result.signatureMatch).toBe(false);
+  });
+
+  it("fails with tampered signature bytes", () => {
+    const snapshot = makeSnapshot();
+    const sig = signContentHash(snapshot.contentHash, ed25519Private);
+    const tampered: DetachedSignature = { ...sig, signature: "aW52YWxpZA==" };
+    const result = verifySignature(snapshot, tampered, ed25519Public);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Cryptographic signature verification failed");
+  });
+});
+
+describe("verifyContentHash", () => {
+  it("passes for a valid snapshot", () => {
+    const snapshot = makeSnapshot();
+    const result = verifyContentHash(snapshot);
+    expect(result.valid).toBe(true);
+    expect(result.expected).toBe(result.actual);
+  });
+
+  it("fails for a tampered snapshot", () => {
+    const snapshot = makeSnapshot();
+    const tool = snapshot.tools["test"];
+    if (tool) tool.description = "TAMPERED";
+    const result = verifyContentHash(snapshot);
+    expect(result.valid).toBe(false);
+    expect(result.expected).not.toBe(result.actual);
+  });
+});
+
+describe("parseSignatureFile", () => {
+  it("parses a valid signature file", () => {
+    const snapshot = makeSnapshot();
+    const sig = signContentHash(snapshot.contentHash, ed25519Private);
+    const json = JSON.stringify(sig, null, 2);
+    const parsed = parseSignatureFile(json);
+    expect(parsed.signatureVersion).toBe("1.0.0");
+    expect(parsed.algorithm).toBe("Ed25519");
+    expect(parsed.contentHash).toBe(snapshot.contentHash);
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => parseSignatureFile("not json")).toThrow("Invalid JSON");
+  });
+
+  it("rejects non-object JSON", () => {
+    expect(() => parseSignatureFile("[]")).toThrow("must contain a JSON object");
+  });
+
+  it("rejects wrong signature version", () => {
+    expect(() => parseSignatureFile('{"signatureVersion":"2.0.0"}')).toThrow(
+      "Unsupported signature version",
+    );
+  });
+
+  it("rejects missing algorithm", () => {
+    expect(() => parseSignatureFile('{"signatureVersion":"1.0.0"}')).toThrow('missing "algorithm"');
+  });
+
+  it("rejects unsupported algorithm", () => {
+    const json = JSON.stringify({
+      signatureVersion: "1.0.0",
+      algorithm: "DSA",
+      contentHash: "sha256:abc",
+      signature: "data",
+      signedAt: "2026-01-01",
+    });
+    expect(() => parseSignatureFile(json)).toThrow('Unsupported algorithm "DSA"');
+  });
+
+  it("rejects missing contentHash", () => {
+    const json = JSON.stringify({
+      signatureVersion: "1.0.0",
+      algorithm: "Ed25519",
+    });
+    expect(() => parseSignatureFile(json)).toThrow('invalid "contentHash"');
+  });
+
+  it("rejects empty signature", () => {
+    const json = JSON.stringify({
+      signatureVersion: "1.0.0",
+      algorithm: "Ed25519",
+      contentHash: "sha256:abc",
+      signature: "",
+      signedAt: "2026-01-01",
+    });
+    expect(() => parseSignatureFile(json)).toThrow('missing "signature"');
+  });
+
+  it("rejects missing signedAt", () => {
+    const json = JSON.stringify({
+      signatureVersion: "1.0.0",
+      algorithm: "Ed25519",
+      contentHash: "sha256:abc",
+      signature: "data",
+    });
+    expect(() => parseSignatureFile(json)).toThrow('missing "signedAt"');
+  });
+});

--- a/packages/core/src/sign.ts
+++ b/packages/core/src/sign.ts
@@ -1,0 +1,218 @@
+/**
+ * Snapshot signing and verification using Ed25519 or RSA-PSS-SHA256.
+ *
+ * The signature covers the `contentHash` field of a snapshot, which itself
+ * is a SHA-256 hash of the canonical tools/resources/prompts content.
+ * Signatures are stored as detached `.mcpc.sig` JSON files.
+ *
+ * @see MILESTONES.md v0.4.0 for the design rationale.
+ */
+
+import { constants, createPrivateKey, createPublicKey, sign, verify } from "node:crypto";
+import { computeContentHash } from "./hash.js";
+import type {
+  DetachedSignature,
+  SignatureAlgorithm,
+  VerifyHashResult,
+  VerifySignatureResult,
+} from "./sign-types.js";
+import { SIGNATURE_VERSION } from "./sign-types.js";
+import type { MCPContractSnapshot } from "./types.js";
+
+/**
+ * Detects the cryptographic algorithm from a PEM-encoded key.
+ *
+ * @param keyPem - PEM-encoded public or private key.
+ * @returns The detected signature algorithm.
+ */
+export function detectKeyAlgorithm(keyPem: string): SignatureAlgorithm {
+  const keyObject = keyPem.includes("PRIVATE") ? createPrivateKey(keyPem) : createPublicKey(keyPem);
+
+  switch (keyObject.asymmetricKeyType) {
+    case "ed25519":
+      return "Ed25519";
+    case "rsa":
+      return "RSA-PSS-SHA256";
+    default:
+      throw new Error(
+        `Unsupported key type "${keyObject.asymmetricKeyType}". Supported types: Ed25519, RSA`,
+      );
+  }
+}
+
+/**
+ * Signs a snapshot's content hash with a private key.
+ *
+ * @param contentHash - The content hash to sign (must start with "sha256:").
+ * @param privateKeyPem - PEM-encoded private key (Ed25519 or RSA).
+ * @returns A detached signature object.
+ */
+export function signContentHash(contentHash: string, privateKeyPem: string): DetachedSignature {
+  if (!contentHash.startsWith("sha256:")) {
+    throw new Error(`Invalid contentHash format: expected "sha256:..." but got "${contentHash}"`);
+  }
+
+  const algorithm = detectKeyAlgorithm(privateKeyPem);
+  const data = Buffer.from(contentHash, "utf-8");
+  const privateKey = createPrivateKey(privateKeyPem);
+
+  let signatureBytes: Buffer;
+  if (algorithm === "Ed25519") {
+    signatureBytes = sign(null, data, privateKey);
+  } else {
+    signatureBytes = sign("sha256", data, {
+      key: privateKey,
+      padding: constants.RSA_PKCS1_PSS_PADDING,
+    });
+  }
+
+  return {
+    signatureVersion: SIGNATURE_VERSION,
+    algorithm,
+    contentHash,
+    signature: signatureBytes.toString("base64"),
+    signedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Verifies a detached signature against a snapshot and public key.
+ *
+ * Performs three checks in order:
+ * 1. Recomputed content hash matches the snapshot's stored hash.
+ * 2. Snapshot's content hash matches the signature's content hash.
+ * 3. Cryptographic signature is valid.
+ *
+ * @param snapshot - The snapshot to verify.
+ * @param signature - The detached signature to verify against.
+ * @param publicKeyPem - PEM-encoded public key.
+ * @returns Structured verification result.
+ */
+export function verifySignature(
+  snapshot: MCPContractSnapshot,
+  signature: DetachedSignature,
+  publicKeyPem: string,
+): VerifySignatureResult {
+  // Step 1: Recompute content hash
+  const recomputed = computeContentHash(snapshot.tools, snapshot.resources, snapshot.prompts);
+  if (recomputed !== snapshot.contentHash) {
+    return {
+      valid: false,
+      error: `Content hash mismatch: stored "${snapshot.contentHash}" but recomputed "${recomputed}"`,
+      contentHashMatch: false,
+      signatureMatch: false,
+    };
+  }
+
+  // Step 2: Check signature references the same hash
+  if (snapshot.contentHash !== signature.contentHash) {
+    return {
+      valid: false,
+      error: `Signature was created for hash "${signature.contentHash}" but snapshot has "${snapshot.contentHash}"`,
+      contentHashMatch: true,
+      signatureMatch: false,
+    };
+  }
+
+  // Step 3: Verify cryptographic signature
+  const data = Buffer.from(signature.contentHash, "utf-8");
+  const signatureBytes = Buffer.from(signature.signature, "base64");
+  const publicKey = createPublicKey(publicKeyPem);
+
+  let isValid: boolean;
+  if (signature.algorithm === "Ed25519") {
+    isValid = verify(null, data, publicKey, signatureBytes);
+  } else if (signature.algorithm === "RSA-PSS-SHA256") {
+    isValid = verify(
+      "sha256",
+      data,
+      {
+        key: publicKey,
+        padding: constants.RSA_PKCS1_PSS_PADDING,
+      },
+      signatureBytes,
+    );
+  } else {
+    return {
+      valid: false,
+      error: `Unsupported signature algorithm "${signature.algorithm}"`,
+      contentHashMatch: true,
+      signatureMatch: false,
+    };
+  }
+
+  if (!isValid) {
+    return {
+      valid: false,
+      error: "Cryptographic signature verification failed",
+      contentHashMatch: true,
+      signatureMatch: false,
+    };
+  }
+
+  return { valid: true, contentHashMatch: true, signatureMatch: true };
+}
+
+/**
+ * Verifies a snapshot's content hash by recomputing it.
+ *
+ * @param snapshot - The snapshot to verify.
+ * @returns Result with the expected (stored) and actual (recomputed) hashes.
+ */
+export function verifyContentHash(snapshot: MCPContractSnapshot): VerifyHashResult {
+  const actual = computeContentHash(snapshot.tools, snapshot.resources, snapshot.prompts);
+  return {
+    valid: actual === snapshot.contentHash,
+    expected: snapshot.contentHash,
+    actual,
+  };
+}
+
+/**
+ * Parses and validates a `.mcpc.sig` JSON string into a DetachedSignature.
+ *
+ * @param json - The raw JSON string from a `.mcpc.sig` file.
+ * @returns The parsed DetachedSignature.
+ */
+export function parseSignatureFile(json: string): DetachedSignature {
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    throw new Error("Invalid JSON in signature file");
+  }
+
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    throw new Error("Signature file must contain a JSON object");
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  if (obj["signatureVersion"] !== SIGNATURE_VERSION) {
+    throw new Error(
+      `Unsupported signature version "${String(obj["signatureVersion"])}" (expected "${SIGNATURE_VERSION}")`,
+    );
+  }
+
+  if (typeof obj["algorithm"] !== "string") {
+    throw new Error('Signature file is missing "algorithm"');
+  }
+
+  if (obj["algorithm"] !== "Ed25519" && obj["algorithm"] !== "RSA-PSS-SHA256") {
+    throw new Error(`Unsupported algorithm "${obj["algorithm"]}" in signature file`);
+  }
+
+  if (typeof obj["contentHash"] !== "string" || !obj["contentHash"].startsWith("sha256:")) {
+    throw new Error('Signature file has invalid "contentHash"');
+  }
+
+  if (typeof obj["signature"] !== "string" || obj["signature"].length === 0) {
+    throw new Error('Signature file is missing "signature"');
+  }
+
+  if (typeof obj["signedAt"] !== "string") {
+    throw new Error('Signature file is missing "signedAt"');
+  }
+
+  return data as DetachedSignature;
+}


### PR DESCRIPTION
Closes #32, closes #33, closes #34

## Summary

- **Snapshot signing** (#32): `mcpdiff sign` / `mcpdiff verify` commands using Ed25519 or RSA-PSS-SHA256 via Node.js `crypto` (zero new dependencies). Produces detached `.mcpc.sig` JSON files.
- **Signed baselines in CI** (#33): `mcpdiff ci --verify-signature --signature-key <path>` verifies baseline signature before diffing. Supports `MCP_SIGNATURE_KEY` env var fallback.
- **Content hash verification** (#34): `mcpdiff verify-hash` recomputes and validates the stored content hash — zero-config integrity check.

## Changes

### Core (`@mcp-contracts/core`)
- `sign-types.ts`: `DetachedSignature`, `SignatureAlgorithm`, `VerifySignatureResult`, `VerifyHashResult` types
- `sign.ts`: `signContentHash()`, `verifySignature()`, `verifyContentHash()`, `detectKeyAlgorithm()`, `parseSignatureFile()`
- 33 new unit tests covering both Ed25519 and RSA key types, tamper detection, and error cases

### CLI (`@mcp-contracts/cli`)
- `sign` command: signs a snapshot with a private key
- `verify` command: verifies a signature with a public key
- `verify-hash` command: checks content hash integrity without keys
- `ci` command: `--verify-signature` and `--signature-key` options
- 12 new CLI tests

### GitHub Action (separate repo)
- `verify-signature` and `signature-key` inputs in `action.yml`
- Verification logic before diff in `src/index.ts`

## Test plan

- [x] `pnpm -r build` — clean build
- [x] `pnpm -r test` — 300 tests pass (135 core + 165 cli)
- [x] `pnpm -r typecheck` — no type errors
- [x] `pnpm run lint` — biome passes clean