### PR TITLE
Project config file (mcpcontracts.json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v2
 npx @mcp-contracts/cli diff v1.mcpc.json v2.mcpc.json
 ```
 
+Tired of repeating `--command`? Put it in a [project config](#project-config-mcpcontractsjson) once and run `mcpdiff baseline verify` with zero flags.
+
 Output:
 ```
   mcp-contracts diff — acme-server v1.0.0 → v1.1.0
@@ -244,6 +246,43 @@ mcpdiff snapshot --url http://localhost:3000/mcp \
 | `--header <header...>` | Custom HTTP headers as `"Key: Value"` (repeatable) |
 | `--config <path>` | Path to `mcp.json` config file |
 | `--server <name>` | Server name from config file |
+
+## Project Config (`mcpcontracts.json`)
+
+Instead of repeating transport and baseline flags on every invocation, put them in an `mcpcontracts.json` at your project root. It is discovered by walking up from the current directory (like `tsconfig.json`), or passed explicitly with the global `--project <path>` option.
+
+```jsonc
+{
+  // How to reach your server — exactly one of the three transport shapes:
+  "server": {
+    "command": "node",
+    "args": ["dist/index.js"],
+    "env": { "API_KEY": "..." }
+    // or: "url": "http://localhost:3000/mcp", "sse": true, "headers": { "Authorization": "..." }
+    // or: "config": "./mcp.json", "name": "my-server"
+  },
+  "baseline": "contracts/baseline.mcpc.json",
+  "failOn": "breaking",
+  "watch": { "paths": ["src"], "debounce": 500 }
+}
+```
+
+With the config in place, the repeated commands need no flags at all:
+
+```bash
+mcpdiff baseline update        # knows the server + baseline path
+mcpdiff baseline verify        # zero flags locally
+mcpdiff ci                     # zero flags in CI
+mcpdiff watch                  # zero flags in dev
+```
+
+The config is read by every command that connects to a live server: `snapshot`, `diff --live`, `baseline update`, `baseline verify`, `ci`, and `watch`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`, `verify-hash`) ignore it.
+
+**Precedence:** explicit CLI flags > config file > built-in defaults. Passing any transport flag (`--command`, `--url`, `--config`, …) ignores the config's `server` block entirely — the two sources are never partially merged. `failOn` applies to `ci` and `watch`; the `watch` block applies to `watch` only.
+
+**Paths** in the config (`baseline`, `watch.paths`, `server.config`) are resolved relative to the config file's directory, so commands behave the same from any subdirectory.
+
+**Validation** is strict: unknown keys are an error (catching typos like `"failon"`), and an invalid config exits with code `2` and a message naming the file and the offending key — even when flags would have overridden it.
 
 ## Why Description Changes are Warnings
 

--- a/packages/cli/src/__tests__/fixtures/fixture-server.mjs
+++ b/packages/cli/src/__tests__/fixtures/fixture-server.mjs
@@ -1,0 +1,35 @@
+/**
+ * Minimal stdio MCP server used by the CLI integration tests.
+ *
+ * Uses the low-level Server API with raw JSON schemas so the fixture only
+ * depends on @modelcontextprotocol/sdk (a direct dependency of the CLI).
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server(
+  { name: "fixture-server", version: "1.0.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "echo",
+      description: "Echo a message back",
+      inputSchema: {
+        type: "object",
+        properties: { message: { type: "string", description: "Message to echo" } },
+        required: ["message"],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => ({
+  content: [{ type: "text", text: String(request.params.arguments?.message ?? "") }],
+}));
+
+await server.connect(new StdioServerTransport());

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -1,7 +1,9 @@
 import { execFile } from "node:child_process";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 
@@ -21,8 +23,27 @@ const V2_WARNING = resolve(FIXTURES_DIR, "server-v2-warning.mcpc.json");
 async function runCli(
   ...args: string[]
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return runCliIn(process.cwd(), ...args);
+}
+
+/**
+ * Runs the CLI with the given arguments from a specific working directory.
+ *
+ * Strips GITHUB_STEP_SUMMARY so `ci` runs don't write to a real step summary
+ * when the test suite itself runs in GitHub Actions.
+ *
+ * @param cwd - Working directory for the CLI process.
+ * @param args - CLI arguments to pass.
+ * @returns stdout, stderr, and exitCode.
+ */
+async function runCliIn(
+  cwd: string,
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const env = { ...process.env };
+  delete env["GITHUB_STEP_SUMMARY"];
   try {
-    const { stdout, stderr } = await execFileAsync("node", [CLI_PATH, ...args]);
+    const { stdout, stderr } = await execFileAsync("node", [CLI_PATH, ...args], { cwd, env });
     return { stdout, stderr, exitCode: 0 };
   } catch (err: unknown) {
     const e = err as { stdout: string; stderr: string; code: number };
@@ -227,5 +248,134 @@ describe("integration: CLI", () => {
       expect(stdout).toContain("--sse");
       expect(stdout).toContain("--header");
     });
+  });
+});
+
+describe("integration: project config (mcpcontracts.json)", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "mcpc-integration-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeProjectConfig(config: unknown): void {
+    writeFileSync(join(projectDir, "mcpcontracts.json"), JSON.stringify(config, null, 2), "utf-8");
+  }
+
+  it("root --help shows the --project option", async () => {
+    const { stdout, exitCode } = await runCli("--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--project");
+  });
+
+  it("runs baseline update, verify, and ci with zero flags", async () => {
+    writeProjectConfig({
+      server: { command: "node", args: [FIXTURE_SERVER] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+
+    const update = await runCliIn(projectDir, "baseline", "update");
+    expect(update.exitCode).toBe(0);
+    expect(existsSync(join(projectDir, "contracts", "baseline.mcpc.json"))).toBe(true);
+
+    const verify = await runCliIn(projectDir, "baseline", "verify");
+    expect(verify.exitCode).toBe(0);
+    expect(verify.stderr).toContain("Baseline verified");
+
+    const ci = await runCliIn(projectDir, "ci", "--format", "json");
+    expect(ci.exitCode).toBe(0);
+    const report = JSON.parse(ci.stdout);
+    expect(report.summary).toMatchObject({ breaking: 0, warning: 0, safe: 0 });
+  });
+
+  it("discovers the config from a subdirectory", async () => {
+    writeProjectConfig({
+      server: { command: "node", args: [FIXTURE_SERVER] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+    const sub = join(projectDir, "src", "nested");
+    mkdirSync(sub, { recursive: true });
+
+    const update = await runCliIn(sub, "baseline", "update");
+    expect(update.exitCode).toBe(0);
+    expect(existsSync(join(projectDir, "contracts", "baseline.mcpc.json"))).toBe(true);
+
+    const verify = await runCliIn(sub, "baseline", "verify");
+    expect(verify.exitCode).toBe(0);
+  });
+
+  it("uses --project to load a config outside the cwd", async () => {
+    writeProjectConfig({
+      server: { command: "node", args: [FIXTURE_SERVER] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+    await runCliIn(projectDir, "baseline", "update");
+
+    const elsewhere = mkdtempSync(join(tmpdir(), "mcpc-elsewhere-"));
+    try {
+      const verify = await runCliIn(
+        elsewhere,
+        "baseline",
+        "verify",
+        "--project",
+        join(projectDir, "mcpcontracts.json"),
+      );
+      expect(verify.exitCode).toBe(0);
+    } finally {
+      rmSync(elsewhere, { recursive: true, force: true });
+    }
+  });
+
+  it("lets explicit flags override the config baseline", async () => {
+    writeProjectConfig({
+      server: { command: "node", args: [FIXTURE_SERVER] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+    await runCliIn(projectDir, "baseline", "update");
+
+    const { stderr, exitCode } = await runCliIn(
+      projectDir,
+      "baseline",
+      "verify",
+      "--baseline",
+      "missing.mcpc.json",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("missing.mcpc.json");
+  });
+
+  it("exits 2 on an invalid config, naming the file and key", async () => {
+    writeProjectConfig({ failon: "breaking" });
+    const { stderr, exitCode } = await runCliIn(projectDir, "snapshot");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("failon");
+    expect(stderr).toContain("mcpcontracts.json");
+  });
+
+  it("exits 2 on an invalid config even when flags specify the transport", async () => {
+    writeProjectConfig({ server: {} });
+    const { stderr, exitCode } = await runCliIn(
+      projectDir,
+      "snapshot",
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("mcpcontracts.json");
+  });
+
+  it("ci without a baseline anywhere explains both options", async () => {
+    writeProjectConfig({ server: { command: "node", args: [FIXTURE_SERVER] } });
+    const { stderr, exitCode } = await runCliIn(projectDir, "ci");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--baseline");
+    expect(stderr).toContain("mcpcontracts.json");
   });
 });

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -309,6 +309,30 @@ describe("integration: project config (mcpcontracts.json)", () => {
     expect(verify.exitCode).toBe(0);
   });
 
+  it("spawns relative stdio commands from the config directory", async () => {
+    // A launcher that only resolves if the server spawns with the config
+    // file's directory as its cwd, not the invoking subdirectory.
+    const launcher = join(projectDir, "srv.mjs");
+    writeFileSync(
+      launcher,
+      `await import(${JSON.stringify(`file://${FIXTURE_SERVER}`)});\n`,
+      "utf-8",
+    );
+    writeProjectConfig({
+      server: { command: "node", args: ["srv.mjs"] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+    const sub = join(projectDir, "deeply", "nested");
+    mkdirSync(sub, { recursive: true });
+
+    const update = await runCliIn(sub, "baseline", "update");
+    expect(update.exitCode).toBe(0);
+
+    const verify = await runCliIn(sub, "baseline", "verify");
+    expect(verify.exitCode).toBe(0);
+    expect(verify.stderr).toContain("Baseline verified");
+  });
+
   it("uses --project to load a config outside the cwd", async () => {
     writeProjectConfig({
       server: { command: "node", args: [FIXTURE_SERVER] },

--- a/packages/cli/src/commands/baseline.test.ts
+++ b/packages/cli/src/commands/baseline.test.ts
@@ -238,12 +238,13 @@ describe("baseline command", () => {
       expect(stderrData).toContain("Failed to read snapshot file");
     });
 
-    it("uses default baseline path", () => {
+    it("has no commander default for --baseline so the project config can supply it", () => {
       const program = createProgram();
       const baselineCmd = program.commands.find((c) => c.name() === "baseline");
       const verifyCmd = baselineCmd?.commands.find((c) => c.name() === "verify");
       const baselineOpt = verifyCmd?.options.find((o) => o.long === "--baseline");
-      expect(baselineOpt?.defaultValue).toBe("contracts/baseline.mcpc.json");
+      expect(baselineOpt?.defaultValue).toBeUndefined();
+      expect(baselineOpt?.description).toContain("contracts/baseline.mcpc.json");
     });
   });
 });

--- a/packages/cli/src/commands/baseline.ts
+++ b/packages/cli/src/commands/baseline.ts
@@ -2,33 +2,29 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { diffSnapshots } from "@mcp-contracts/core";
 import { Command } from "commander";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
-import { CliExitError, handleErrors, readSnapshotFile, writeOutput } from "../utils.js";
+import {
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import {
+  CliExitError,
+  getRootOpts,
+  handleErrors,
+  readSnapshotFile,
+  writeOutput,
+} from "../utils.js";
 import { captureSnapshot } from "./capture.js";
 
 const DEFAULT_BASELINE_PATH = "contracts/baseline.mcpc.json";
 
 /**
- * Resolves the root program options from a deeply nested subcommand.
- *
- * @param cmd - The current Command instance.
- * @returns The root program's parsed options.
- */
-function getRootOpts(cmd: Command): Record<string, unknown> {
-  let current: Command | null = cmd;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
-}
-
-/**
  * Creates the `baseline update` subcommand.
  *
  * Captures a snapshot from a live server and writes it to a baseline path.
- * Uses the global --output option from the root program, defaulting to
- * contracts/baseline.mcpc.json if not specified.
+ * The path comes from the global --output option, then the project config's
+ * "baseline", then contracts/baseline.mcpc.json.
  *
  * @returns A Commander Command instance.
  */
@@ -43,19 +39,12 @@ export function createBaselineUpdateCommand(): Command {
     handleErrors(async (options: Record<string, unknown>) => {
       const rootOpts = getRootOpts(cmd);
       const quiet = rootOpts["quiet"] === true;
-      const outputPath = (rootOpts["output"] as string | undefined) ?? DEFAULT_BASELINE_PATH;
+      const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+      const outputPath =
+        resolveBaselinePath(rootOpts["output"] as string | undefined, project) ??
+        DEFAULT_BASELINE_PATH;
 
-      const transportOpts: TransportOptions = {
-        command: options["command"] as string | undefined,
-        url: options["url"] as string | undefined,
-        config: options["config"] as string | undefined,
-        server: options["server"] as string | undefined,
-        args: options["args"] as string[] | undefined,
-        env: options["env"] as string[] | undefined,
-        sse: options["sse"] === true ? true : undefined,
-        header: options["header"] as string[] | undefined,
-      };
-      const config = resolveTransport(transportOpts);
+      const config = resolveTransportOrProject(options, project);
 
       const { snapshot } = await captureSnapshot({ transport: config, quiet });
 
@@ -86,47 +75,42 @@ export function createBaselineVerifyCommand(): Command {
 
   addTransportOptions(cmd);
 
-  cmd.option("--baseline <path>", "Path to baseline file", DEFAULT_BASELINE_PATH).action(
-    handleErrors(async (options: Record<string, unknown>) => {
-      const rootOpts = getRootOpts(cmd);
-      const quiet = rootOpts["quiet"] === true;
-      const baselinePath = (options["baseline"] as string) ?? DEFAULT_BASELINE_PATH;
+  cmd
+    .option("--baseline <path>", `Path to baseline file (default: "${DEFAULT_BASELINE_PATH}")`)
+    .action(
+      handleErrors(async (options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const quiet = rootOpts["quiet"] === true;
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+        const baselinePath =
+          resolveBaselinePath(options["baseline"] as string | undefined, project) ??
+          DEFAULT_BASELINE_PATH;
 
-      const baseline = readSnapshotFile(baselinePath);
+        const baseline = readSnapshotFile(baselinePath);
 
-      const transportOpts: TransportOptions = {
-        command: options["command"] as string | undefined,
-        url: options["url"] as string | undefined,
-        config: options["config"] as string | undefined,
-        server: options["server"] as string | undefined,
-        args: options["args"] as string[] | undefined,
-        env: options["env"] as string[] | undefined,
-        sse: options["sse"] === true ? true : undefined,
-        header: options["header"] as string[] | undefined,
-      };
-      const config = resolveTransport(transportOpts);
+        const config = resolveTransportOrProject(options, project);
 
-      const { snapshot: current } = await captureSnapshot({ transport: config, quiet });
+        const { snapshot: current } = await captureSnapshot({ transport: config, quiet });
 
-      if (baseline.contentHash === current.contentHash) {
-        if (!quiet) {
-          process.stderr.write("Baseline verified: contract unchanged\n");
+        if (baseline.contentHash === current.contentHash) {
+          if (!quiet) {
+            process.stderr.write("Baseline verified: contract unchanged\n");
+          }
+          return;
         }
-        return;
-      }
 
-      const report = diffSnapshots(baseline, current);
-      const { breaking, warning, safe } = report.summary;
-      const parts: string[] = [];
-      if (breaking > 0) parts.push(`${breaking} breaking`);
-      if (warning > 0) parts.push(`${warning} warning`);
-      if (safe > 0) parts.push(`${safe} safe`);
-      const summary = parts.length > 0 ? parts.join(", ") : "0";
+        const report = diffSnapshots(baseline, current);
+        const { breaking, warning, safe } = report.summary;
+        const parts: string[] = [];
+        if (breaking > 0) parts.push(`${breaking} breaking`);
+        if (warning > 0) parts.push(`${warning} warning`);
+        if (safe > 0) parts.push(`${safe} safe`);
+        const summary = parts.length > 0 ? parts.join(", ") : "0";
 
-      process.stderr.write(`Baseline mismatch: contract has changed (${summary} changes)\n`);
-      throw new CliExitError(1);
-    }),
-  );
+        process.stderr.write(`Baseline mismatch: contract has changed (${summary} changes)\n`);
+        throw new CliExitError(1);
+      }),
+    );
 
   return cmd;
 }

--- a/packages/cli/src/commands/ci.ts
+++ b/packages/cli/src/commands/ci.ts
@@ -12,10 +12,15 @@ import {
 } from "@mcp-contracts/core";
 import { Command } from "commander";
 import { detectCIEnvironment } from "../ci-env.js";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
+import {
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
 import {
   CliExitError,
+  getRootOpts,
   handleErrors,
   readSnapshotFile,
   resolveFormat,
@@ -58,8 +63,8 @@ export function createCiCommand(): Command {
   addTransportOptions(cmd);
 
   cmd
-    .requiredOption("--baseline <path>", "Path to baseline snapshot (required)")
-    .option("--fail-on <level>", "Severity threshold for exit code 1", "breaking")
+    .option("--baseline <path>", "Path to baseline snapshot")
+    .option("--fail-on <level>", 'Severity threshold for exit code 1 (default: "breaking")')
     .option("--severity <level>", "Minimum severity to display", "safe")
     .option("--webhook <url>", "POST diff results to a webhook URL")
     .option("--verify-signature", "Require valid signature on baseline before diffing")
@@ -72,32 +77,34 @@ export function createCiCommand(): Command {
         const outputPath = rootOpts["output"] as string | undefined;
         const explicitFormat = rootOpts["format"] as string | undefined;
 
-        const severity = parseSeverity(options["severity"] as string, "--severity");
-        const failOn = parseSeverity(options["failOn"] as string, "--fail-on");
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
 
-        const baseline = readSnapshotFile(options["baseline"] as string);
+        const severity = parseSeverity(options["severity"] as string, "--severity");
+        const failOn = parseSeverity(
+          (options["failOn"] as string | undefined) ?? project?.config.failOn ?? "breaking",
+          "--fail-on",
+        );
+
+        const baselinePath = resolveBaselinePath(
+          options["baseline"] as string | undefined,
+          project,
+        );
+        if (!baselinePath) {
+          throw new Error('--baseline is required (or set "baseline" in mcpcontracts.json)');
+        }
+        const baseline = readSnapshotFile(baselinePath);
 
         // Verify baseline signature if requested
         if (options["verifySignature"] === true) {
           verifyBaselineSignature(
             baseline,
-            options["baseline"] as string,
+            baselinePath,
             options["signatureKey"] as string | undefined,
             quiet,
           );
         }
 
-        const transportOpts: TransportOptions = {
-          command: options["command"] as string | undefined,
-          url: options["url"] as string | undefined,
-          config: options["config"] as string | undefined,
-          server: options["server"] as string | undefined,
-          args: options["args"] as string[] | undefined,
-          env: options["env"] as string[] | undefined,
-          sse: options["sse"] === true ? true : undefined,
-          header: options["header"] as string[] | undefined,
-        };
-        const config = resolveTransport(transportOpts);
+        const config = resolveTransportOrProject(options, project);
 
         const { snapshot: current } = await captureSnapshot({ transport: config, quiet });
 
@@ -144,7 +151,7 @@ export function createCiCommand(): Command {
         if (webhookUrl) {
           const payload = createWebhookPayload(report, {
             trigger: "ci",
-            baselinePath: options["baseline"] as string,
+            baselinePath,
           });
           const webhookResult = await sendWebhook(webhookUrl, payload);
           if (!webhookResult.success) {
@@ -166,20 +173,6 @@ export function createCiCommand(): Command {
     );
 
   return cmd;
-}
-
-/**
- * Resolves the root program options from a deeply nested subcommand.
- *
- * @param cmd - The current Command instance.
- * @returns The root program's parsed options.
- */
-function getRootOpts(cmd: Command): Record<string, unknown> {
-  let current: Command | null = cmd;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
 }
 
 /**

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -8,8 +8,13 @@ import {
   SEVERITY_ORDER,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
+import type { LoadedProjectConfig } from "../project-config.js";
+import {
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
 import {
   CliExitError,
   handleErrors,
@@ -44,6 +49,7 @@ function parseSeverity(value: string, label: string): Severity {
  * @param afterPath - Path to snapshot file (may be undefined in live mode).
  * @param live - Whether live mode is enabled.
  * @param options - CLI options containing transport settings.
+ * @param project - The loaded project config, if any (live mode only).
  * @param quiet - Suppress non-essential output.
  * @returns The "after" snapshot.
  */
@@ -51,6 +57,7 @@ async function resolveAfterSnapshot(
   afterPath: string | undefined,
   live: boolean,
   options: Record<string, unknown>,
+  project: LoadedProjectConfig | null,
   quiet: boolean,
 ): Promise<MCPContractSnapshot> {
   if (!live) {
@@ -60,18 +67,7 @@ async function resolveAfterSnapshot(
     return readSnapshotFile(afterPath);
   }
 
-  const transportOpts: TransportOptions = {
-    command: options["command"] as string | undefined,
-    url: options["url"] as string | undefined,
-    config: options["config"] as string | undefined,
-    server: options["server"] as string | undefined,
-    args: options["args"] as string[] | undefined,
-    env: options["env"] as string[] | undefined,
-    sse: options["sse"] === true ? true : undefined,
-    header: options["header"] as string[] | undefined,
-  };
-
-  const config = resolveTransport(transportOpts);
+  const config = resolveTransportOrProject(options, project);
   const { snapshot } = await captureSnapshot({ transport: config, quiet });
   return snapshot;
 }
@@ -81,6 +77,7 @@ interface FileDiffOptions {
   beforePath: string;
   afterPath: string | undefined;
   live: boolean;
+  project: LoadedProjectConfig | null;
   options: Record<string, unknown>;
   severity: Severity;
   failOn: Severity;
@@ -101,6 +98,7 @@ async function runFileDiff(params: FileDiffOptions): Promise<void> {
     params.afterPath,
     params.live,
     params.options,
+    params.project,
     params.quiet,
   );
 
@@ -206,16 +204,27 @@ export function createDiffCommand(): Command {
           return;
         }
 
-        if (!beforePath) {
+        // In live mode the project config can supply both the baseline
+        // ("before") and the server transport; file-to-file diffs ignore it.
+        const project = live
+          ? loadProjectConfig(parentOpts["project"] as string | undefined)
+          : null;
+        const resolvedBefore =
+          beforePath ?? (live ? resolveBaselinePath(undefined, project) : undefined);
+
+        if (!resolvedBefore) {
           throw new Error(
-            "Two snapshot file paths are required (or use --baseline for a composition diff)",
+            live
+              ? 'A baseline snapshot path is required (or set "baseline" in mcpcontracts.json)'
+              : "Two snapshot file paths are required (or use --baseline for a composition diff)",
           );
         }
 
         await runFileDiff({
-          beforePath,
+          beforePath: resolvedBefore,
           afterPath,
           live,
+          project,
           options,
           severity,
           failOn,

--- a/packages/cli/src/commands/mcp-client.ts
+++ b/packages/cli/src/commands/mcp-client.ts
@@ -15,6 +15,8 @@ export interface ResolvedTransport {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
+  /** Working directory for the spawned stdio server (defaults to the CWD). */
+  cwd?: string;
   url?: string;
   headers?: Record<string, string>;
 }
@@ -52,6 +54,7 @@ export async function connectToServer(config: ResolvedTransport): Promise<Connec
       command: config.command,
       args: config.args,
       env: { ...getDefaultEnvironment(), ...config.env },
+      cwd: config.cwd,
     });
   } else if (config.transport === "sse") {
     if (!config.url) {

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -2,9 +2,9 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Command } from "commander";
 import { listConfigServers } from "../mcp-config.js";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
-import { handleErrors, writeOutput } from "../utils.js";
+import { loadProjectConfig, resolveTransportOrProject } from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import { getRootOpts, handleErrors, writeOutput } from "../utils.js";
 import { captureSnapshot } from "./capture.js";
 import { captureAllServers } from "./capture-all.js";
 
@@ -63,9 +63,9 @@ export function createSnapshotCommand(): Command {
 
   cmd.action(
     handleErrors(async (options: Record<string, unknown>) => {
-      const parentOpts = cmd.parent?.opts() ?? {};
-      const outputPath = parentOpts["output"] as string | undefined;
-      const quiet = parentOpts["quiet"] === true;
+      const rootOpts = getRootOpts(cmd);
+      const outputPath = rootOpts["output"] as string | undefined;
+      const quiet = rootOpts["quiet"] === true;
 
       if (options["all"] === true) {
         const configPath = options["config"] as string | undefined;
@@ -76,17 +76,8 @@ export function createSnapshotCommand(): Command {
         return;
       }
 
-      const transportOpts: TransportOptions = {
-        command: options["command"] as string | undefined,
-        url: options["url"] as string | undefined,
-        config: options["config"] as string | undefined,
-        server: options["server"] as string | undefined,
-        args: options["args"] as string[] | undefined,
-        env: options["env"] as string[] | undefined,
-        sse: options["sse"] === true ? true : undefined,
-        header: options["header"] as string[] | undefined,
-      };
-      const config = resolveTransport(transportOpts);
+      const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+      const config = resolveTransportOrProject(options, project);
 
       const { snapshot } = await captureSnapshot({ transport: config, quiet });
 

--- a/packages/cli/src/commands/watch.test.ts
+++ b/packages/cli/src/commands/watch.test.ts
@@ -41,11 +41,12 @@ describe("watch command", () => {
     expect(baselineOpt?.required).toBe(true);
   });
 
-  it("defaults --debounce to 500", () => {
+  it("has no commander default for --debounce so the project config can supply it", () => {
     const program = createProgram();
     const watchCmd = program.commands.find((c) => c.name() === "watch");
     const debounceOpt = watchCmd?.options.find((o) => o.long === "--debounce");
-    expect(debounceOpt?.defaultValue).toBe("500");
+    expect(debounceOpt?.defaultValue).toBeUndefined();
+    expect(debounceOpt?.description).toContain("500");
   });
 
   it("defaults --severity to safe", () => {
@@ -55,17 +56,19 @@ describe("watch command", () => {
     expect(severityOpt?.defaultValue).toBe("safe");
   });
 
-  it("defaults --fail-on to breaking", () => {
+  it("has no commander default for --fail-on so the project config can supply it", () => {
     const program = createProgram();
     const watchCmd = program.commands.find((c) => c.name() === "watch");
     const failOnOpt = watchCmd?.options.find((o) => o.long === "--fail-on");
-    expect(failOnOpt?.defaultValue).toBe("breaking");
+    expect(failOnOpt?.defaultValue).toBeUndefined();
+    expect(failOnOpt?.description).toContain("breaking");
   });
 
-  it("defaults --watch-paths to current directory", () => {
+  it("has no commander default for --watch-paths so the project config can supply it", () => {
     const program = createProgram();
     const watchCmd = program.commands.find((c) => c.name() === "watch");
     const watchPathsOpt = watchCmd?.options.find((o) => o.long === "--watch-paths");
-    expect(watchPathsOpt?.defaultValue).toEqual(["."]);
+    expect(watchPathsOpt?.defaultValue).toBeUndefined();
+    expect(watchPathsOpt?.description).toContain(".");
   });
 });

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -16,9 +16,15 @@ import {
   SEVERITY_ORDER,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
-import { handleErrors, readSnapshotFile } from "../utils.js";
+import type { LoadedProjectConfig } from "../project-config.js";
+import {
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveProjectPath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import { getRootOpts, handleErrors, readSnapshotFile } from "../utils.js";
 import {
   clearScreen,
   formatWatchCycle,
@@ -112,6 +118,53 @@ function checkFailThreshold(
   }
 }
 
+/** Watch options resolved from CLI flags and the project config. */
+interface ResolvedWatchOptions {
+  severity: Severity;
+  failOn: Severity;
+  debounceMs: number;
+  watchPaths: string[];
+  baselinePath: string;
+  webhookUrl: string | undefined;
+  shouldClear: boolean;
+}
+
+/**
+ * Resolves the watch command's options with flags > project config > defaults
+ * precedence.
+ *
+ * @param options - The raw parsed options record from the command action.
+ * @param project - The loaded project config, if any.
+ * @returns The fully resolved watch options.
+ */
+function resolveWatchOptions(
+  options: Record<string, unknown>,
+  project: LoadedProjectConfig | null,
+): ResolvedWatchOptions {
+  const severity = parseSeverity((options["severity"] as string) ?? "safe", "--severity");
+  const failOn = parseSeverity(
+    (options["failOn"] as string | undefined) ?? project?.config.failOn ?? "breaking",
+    "--fail-on",
+  );
+  const debounceMs = Number.parseInt(
+    (options["debounce"] as string | undefined) ?? String(project?.config.watch?.debounce ?? 500),
+    10,
+  );
+  const projectWatchPaths = project?.config.watch?.paths?.map((p) =>
+    resolveProjectPath(project, p),
+  );
+  const watchPaths = (options["watchPaths"] as string[] | undefined) ?? projectWatchPaths ?? ["."];
+  const baselinePath = resolveBaselinePath(options["baseline"] as string | undefined, project);
+  if (!baselinePath) {
+    throw new Error('--baseline is required (or set "baseline" in mcpcontracts.json)');
+  }
+  const webhookUrl = options["webhook"] as string | undefined;
+  const shouldClear =
+    options["clear"] === true || (options["clear"] === undefined && process.stdout.isTTY);
+
+  return { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear };
+}
+
 /**
  * Creates the `watch` subcommand for the mcpdiff CLI.
  *
@@ -128,26 +181,21 @@ export function createWatchCommand(): Command {
   addTransportOptions(cmd);
 
   cmd
-    .requiredOption("--baseline <path>", "Path to baseline snapshot")
-    .option("--watch-paths <paths...>", "Paths to watch for changes", ["."])
-    .option("--debounce <ms>", "Debounce interval in milliseconds", "500")
+    .option("--baseline <path>", "Path to baseline snapshot")
+    .option("--watch-paths <paths...>", 'Paths to watch for changes (default: ".")')
+    .option("--debounce <ms>", "Debounce interval in milliseconds (default: 500)")
     .option("--severity <level>", "Minimum severity to display", "safe")
-    .option("--fail-on <level>", "Severity threshold", "breaking")
+    .option("--fail-on <level>", 'Severity threshold (default: "breaking")')
     .option("--webhook <url>", "POST diffs on each cycle")
     .option("--clear", "Clear screen between diffs")
     .action(
       handleErrors(async (options: Record<string, unknown>) => {
-        const parentOpts = cmd.parent?.opts() ?? {};
-        const quiet = parentOpts["quiet"] === true;
+        const rootOpts = getRootOpts(cmd);
+        const quiet = rootOpts["quiet"] === true;
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
 
-        const severity = parseSeverity((options["severity"] as string) ?? "safe", "--severity");
-        const failOn = parseSeverity((options["failOn"] as string) ?? "breaking", "--fail-on");
-        const debounceMs = Number.parseInt(options["debounce"] as string, 10);
-        const watchPaths = options["watchPaths"] as string[];
-        const baselinePath = options["baseline"] as string;
-        const webhookUrl = options["webhook"] as string | undefined;
-        const shouldClear =
-          options["clear"] === true || (options["clear"] === undefined && process.stdout.isTTY);
+        const { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear } =
+          resolveWatchOptions(options, project);
 
         const config = createWatchConfig({
           debounceMs,
@@ -156,17 +204,7 @@ export function createWatchCommand(): Command {
           failOn,
         });
 
-        const transportOpts: TransportOptions = {
-          command: options["command"] as string | undefined,
-          url: options["url"] as string | undefined,
-          config: options["config"] as string | undefined,
-          server: options["server"] as string | undefined,
-          args: options["args"] as string[] | undefined,
-          env: options["env"] as string[] | undefined,
-          sse: options["sse"] === true ? true : undefined,
-          header: options["header"] as string[] | undefined,
-        };
-        const transport = resolveTransport(transportOpts);
+        const transport = resolveTransportOrProject(options, project);
 
         // Print header
         process.stderr.write(formatWatchHeader(baselinePath, watchPaths, debounceMs));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,11 @@ program
   .option("--no-color", "Disable colored output")
   .option("-o, --output <path>", "Output file path")
   .option("--quiet", "Suppress non-essential output")
-  .option("--verbose", "Show detailed information");
+  .option("--verbose", "Show detailed information")
+  .option(
+    "--project <path>",
+    "Path to mcpcontracts.json (default: discovered by walking up from the CWD)",
+  );
 
 program.addCommand(createBaselineCommand());
 program.addCommand(createCheckConflictsCommand());

--- a/packages/cli/src/project-config.test.ts
+++ b/packages/cli/src/project-config.test.ts
@@ -1,0 +1,219 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  discoverProjectConfig,
+  type LoadedProjectConfig,
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveProjectTransport,
+  resolveTransportOrProject,
+} from "./project-config.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mcpc-project-config-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeConfig(targetDir: string, config: unknown): string {
+  const path = join(targetDir, "mcpcontracts.json");
+  writeFileSync(path, JSON.stringify(config, null, 2), "utf-8");
+  return path;
+}
+
+function loaded(config: Record<string, unknown>): LoadedProjectConfig {
+  const path = writeConfig(dir, config);
+  const result = loadProjectConfig(path);
+  if (!result) {
+    throw new Error("expected config to load");
+  }
+  return result;
+}
+
+describe("discoverProjectConfig", () => {
+  it("finds the config in the start directory", () => {
+    const path = writeConfig(dir, {});
+    expect(discoverProjectConfig(dir)).toBe(resolve(path));
+  });
+
+  it("walks up to a parent directory", () => {
+    const path = writeConfig(dir, {});
+    const nested = join(dir, "a", "b");
+    mkdirSync(nested, { recursive: true });
+    expect(discoverProjectConfig(nested)).toBe(resolve(path));
+  });
+
+  it("prefers the nearest config", () => {
+    writeConfig(dir, {});
+    const nested = join(dir, "sub");
+    mkdirSync(nested);
+    const nearest = writeConfig(nested, {});
+    expect(discoverProjectConfig(nested)).toBe(resolve(nearest));
+  });
+
+  it("returns null when no config exists", () => {
+    expect(discoverProjectConfig(dir)).toBeNull();
+  });
+});
+
+describe("loadProjectConfig", () => {
+  it("returns null when discovery finds nothing", () => {
+    expect(loadProjectConfig(undefined, dir)).toBeNull();
+  });
+
+  it("discovers and loads a valid config", () => {
+    writeConfig(dir, { baseline: "contracts/baseline.mcpc.json" });
+    const result = loadProjectConfig(undefined, dir);
+    expect(result?.config.baseline).toBe("contracts/baseline.mcpc.json");
+    expect(result?.dir).toBe(resolve(dir));
+  });
+
+  it("throws when an explicit path does not exist", () => {
+    expect(() => loadProjectConfig(join(dir, "missing.json"))).toThrow(/not found/);
+  });
+
+  it("loads an explicit path relative to the cwd", () => {
+    const nested = join(dir, "configs");
+    mkdirSync(nested);
+    writeConfig(nested, { failOn: "warning" });
+    const result = loadProjectConfig(join("configs", "mcpcontracts.json"), dir);
+    expect(result?.config.failOn).toBe("warning");
+  });
+
+  it("throws on invalid JSON, naming the file", () => {
+    const path = join(dir, "mcpcontracts.json");
+    writeFileSync(path, "{ not json", "utf-8");
+    expect(() => loadProjectConfig(undefined, dir)).toThrow(path);
+  });
+
+  it("throws on an invalid config, naming the file and the key", () => {
+    writeConfig(dir, { failon: "breaking" });
+    const attempt = () => loadProjectConfig(undefined, dir);
+    expect(attempt).toThrow(/failon/);
+    expect(attempt).toThrow(/mcpcontracts\.json/);
+  });
+});
+
+describe("resolveProjectTransport", () => {
+  it("resolves a command server to stdio", () => {
+    const project = loaded({
+      server: { command: "node", args: ["server.js"], env: { A: "b" } },
+    });
+    expect(resolveProjectTransport(project)).toEqual({
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      env: { A: "b" },
+    });
+  });
+
+  it("resolves a url server to streamable-http or sse", () => {
+    const http = loaded({ server: { url: "http://localhost:3000/mcp" } });
+    expect(resolveProjectTransport(http)).toEqual({
+      transport: "streamable-http",
+      url: "http://localhost:3000/mcp",
+      headers: undefined,
+    });
+
+    const sse = loaded({
+      server: { url: "http://localhost:3000/sse", sse: true, headers: { "X-Key": "v" } },
+    });
+    expect(resolveProjectTransport(sse)).toEqual({
+      transport: "sse",
+      url: "http://localhost:3000/sse",
+      headers: { "X-Key": "v" },
+    });
+  });
+
+  it("resolves a config reference relative to the project config", () => {
+    writeFileSync(
+      join(dir, "mcp.json"),
+      JSON.stringify({ mcpServers: { alpha: { command: "node", args: ["a.js"] } } }),
+      "utf-8",
+    );
+    const project = loaded({ server: { config: "./mcp.json", name: "alpha" } });
+    expect(resolveProjectTransport(project)).toEqual({
+      transport: "stdio",
+      command: "node",
+      args: ["a.js"],
+      env: undefined,
+    });
+  });
+
+  it("throws when the config has no server block", () => {
+    const project = loaded({ baseline: "b.mcpc.json" });
+    expect(() => resolveProjectTransport(project)).toThrow(/no "server" block/);
+  });
+});
+
+describe("resolveTransportOrProject", () => {
+  it("uses the project server when no transport flags are given", () => {
+    const project = loaded({ server: { command: "node", args: ["server.js"] } });
+    const transport = resolveTransportOrProject({}, project);
+    expect(transport).toEqual({
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      env: undefined,
+    });
+  });
+
+  it("ignores the project server entirely when a transport flag is given", () => {
+    const project = loaded({ server: { command: "node", args: ["config.js"] } });
+    const transport = resolveTransportOrProject({ command: "deno" }, project);
+    expect(transport).toEqual({
+      transport: "stdio",
+      command: "deno",
+      args: undefined,
+      env: undefined,
+    });
+  });
+
+  it("does not merge partial flags with the project server", () => {
+    const project = loaded({ server: { command: "node", args: ["config.js"] } });
+    expect(() => resolveTransportOrProject({ args: ["other.js"] }, project)).toThrow(
+      /Specify one of/,
+    );
+  });
+
+  it("mentions the config file when it exists without a server block", () => {
+    const project = loaded({ baseline: "b.mcpc.json" });
+    expect(() => resolveTransportOrProject({}, project)).toThrow(/add a "server" block/);
+  });
+
+  it("suggests creating a config when none exists", () => {
+    expect(() => resolveTransportOrProject({}, null)).toThrow(/mcpcontracts\.json/);
+  });
+});
+
+describe("resolveBaselinePath", () => {
+  it("prefers the flag value", () => {
+    const project = loaded({ baseline: "contracts/baseline.mcpc.json" });
+    expect(resolveBaselinePath("flag.mcpc.json", project)).toBe("flag.mcpc.json");
+  });
+
+  it("resolves the config baseline against the config directory", () => {
+    const project = loaded({ baseline: "contracts/baseline.mcpc.json" });
+    expect(resolveBaselinePath(undefined, project)).toBe(
+      resolve(dir, "contracts/baseline.mcpc.json"),
+    );
+  });
+
+  it("keeps an absolute config baseline as-is", () => {
+    const absolute = join(dir, "abs.mcpc.json");
+    const project = loaded({ baseline: absolute });
+    expect(resolveBaselinePath(undefined, project)).toBe(absolute);
+  });
+
+  it("returns undefined when neither source has a baseline", () => {
+    expect(resolveBaselinePath(undefined, null)).toBeUndefined();
+    const project = loaded({ failOn: "warning" });
+    expect(resolveBaselinePath(undefined, project)).toBeUndefined();
+  });
+});

--- a/packages/cli/src/project-config.test.ts
+++ b/packages/cli/src/project-config.test.ts
@@ -110,6 +110,7 @@ describe("resolveProjectTransport", () => {
       command: "node",
       args: ["server.js"],
       env: { A: "b" },
+      cwd: project.dir,
     });
   });
 
@@ -143,6 +144,7 @@ describe("resolveProjectTransport", () => {
       command: "node",
       args: ["a.js"],
       env: undefined,
+      cwd: project.dir,
     });
   });
 
@@ -161,6 +163,7 @@ describe("resolveTransportOrProject", () => {
       command: "node",
       args: ["server.js"],
       env: undefined,
+      cwd: project.dir,
     });
   });
 

--- a/packages/cli/src/project-config.ts
+++ b/packages/cli/src/project-config.ts
@@ -121,6 +121,10 @@ export function resolveProjectPath(project: LoadedProjectConfig, path: string): 
 /**
  * Resolves the project config's server block into a transport.
  *
+ * Stdio servers spawn with the config file's directory as their working
+ * directory, so relative command args (e.g. "node server.js") work no matter
+ * which subdirectory the CLI runs from.
+ *
  * @param project - The loaded project config.
  * @returns The resolved transport configuration.
  */
@@ -135,6 +139,7 @@ export function resolveProjectTransport(project: LoadedProjectConfig): ResolvedT
       command: server.command,
       args: server.args,
       env: server.env,
+      cwd: project.dir,
     };
   }
   if (isProjectServerUrl(server)) {
@@ -144,7 +149,12 @@ export function resolveProjectTransport(project: LoadedProjectConfig): ResolvedT
       headers: server.headers,
     };
   }
-  return readMcpConfig(resolveProjectPath(project, server.config), server.name);
+  const mcpConfigPath = resolveProjectPath(project, server.config);
+  const resolved = readMcpConfig(mcpConfigPath, server.name);
+  if (resolved.transport === "stdio") {
+    resolved.cwd = dirname(mcpConfigPath);
+  }
+  return resolved;
 }
 
 /**

--- a/packages/cli/src/project-config.ts
+++ b/packages/cli/src/project-config.ts
@@ -1,0 +1,198 @@
+/**
+ * mcpcontracts.json discovery, loading, and option resolution.
+ *
+ * The schema and validation live in @mcp-contracts/core; this module handles
+ * the I/O side: finding the file by walking up from the CWD, reading it, and
+ * resolving CLI options with flags > config file > built-in defaults
+ * precedence.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import type { ProjectConfig } from "@mcp-contracts/core";
+import {
+  isProjectServerCommand,
+  isProjectServerUrl,
+  PROJECT_CONFIG_FILENAME,
+  parseProjectConfig,
+} from "@mcp-contracts/core";
+import type { ResolvedTransport } from "./commands/mcp-client.js";
+import { readMcpConfig } from "./mcp-config.js";
+import { extractTransportOptions, hasTransportFlags, resolveTransport } from "./transport.js";
+
+/** A project config together with where it was found. */
+export interface LoadedProjectConfig {
+  /** Absolute path to the config file. */
+  path: string;
+  /** Directory containing the config file; base for its relative paths. */
+  dir: string;
+  /** The validated config contents. */
+  config: ProjectConfig;
+}
+
+/**
+ * Finds the nearest mcpcontracts.json by walking up from a directory.
+ *
+ * @param startDir - Directory to start the search from.
+ * @returns Absolute path to the config file, or null if none exists.
+ */
+export function discoverProjectConfig(startDir: string): string | null {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = join(dir, PROJECT_CONFIG_FILENAME);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Loads and validates the project config.
+ *
+ * With an explicit path (--project), the file must exist. Otherwise the file
+ * is discovered by walking up from the CWD, and its absence is not an error.
+ * A file that exists but fails to parse or validate always throws, so typos
+ * are surfaced even when flags would have overridden the config.
+ *
+ * @param explicitPath - Path from the --project option, if given.
+ * @param cwd - Directory to resolve and discover from (defaults to process.cwd()).
+ * @returns The loaded config, or null when no config file exists.
+ */
+export function loadProjectConfig(
+  explicitPath: string | undefined,
+  cwd: string = process.cwd(),
+): LoadedProjectConfig | null {
+  let path: string;
+  if (explicitPath) {
+    path = resolve(cwd, explicitPath);
+    if (!existsSync(path)) {
+      throw new Error(`Project config file "${path}" not found`);
+    }
+  } else {
+    const discovered = discoverProjectConfig(cwd);
+    if (!discovered) {
+      return null;
+    }
+    path = discovered;
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read project config "${path}": ${message}`);
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON in project config "${path}"`);
+  }
+
+  let config: ProjectConfig;
+  try {
+    config = parseProjectConfig(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`${message} (in "${path}")`);
+  }
+
+  return { path, dir: dirname(path), config };
+}
+
+/**
+ * Resolves a possibly-relative path against the config file's directory.
+ *
+ * @param project - The loaded project config.
+ * @param path - Path from the config file.
+ * @returns An absolute path.
+ */
+export function resolveProjectPath(project: LoadedProjectConfig, path: string): string {
+  return isAbsolute(path) ? path : resolve(project.dir, path);
+}
+
+/**
+ * Resolves the project config's server block into a transport.
+ *
+ * @param project - The loaded project config.
+ * @returns The resolved transport configuration.
+ */
+export function resolveProjectTransport(project: LoadedProjectConfig): ResolvedTransport {
+  const server = project.config.server;
+  if (!server) {
+    throw new Error(`Project config "${project.path}" has no "server" block`);
+  }
+  if (isProjectServerCommand(server)) {
+    return {
+      transport: "stdio",
+      command: server.command,
+      args: server.args,
+      env: server.env,
+    };
+  }
+  if (isProjectServerUrl(server)) {
+    return {
+      transport: server.sse ? "sse" : "streamable-http",
+      url: server.url,
+      headers: server.headers,
+    };
+  }
+  return readMcpConfig(resolveProjectPath(project, server.config), server.name);
+}
+
+/**
+ * Resolves the transport from CLI flags or the project config's server block.
+ *
+ * Any transport flag on the command line means the config's server block is
+ * ignored entirely; the two sources are never partially merged.
+ *
+ * @param options - The raw parsed options record from a command action.
+ * @param project - The loaded project config, if any.
+ * @returns The resolved transport configuration.
+ */
+export function resolveTransportOrProject(
+  options: Record<string, unknown>,
+  project: LoadedProjectConfig | null,
+): ResolvedTransport {
+  const flags = extractTransportOptions(options);
+  if (hasTransportFlags(flags)) {
+    return resolveTransport(flags);
+  }
+  if (project?.config.server) {
+    return resolveProjectTransport(project);
+  }
+  const hint = project
+    ? `add a "server" block to "${project.path}"`
+    : `create an ${PROJECT_CONFIG_FILENAME} with a "server" block`;
+  throw new Error(`Specify one of: --command, --url, or --config (or ${hint})`);
+}
+
+/**
+ * Resolves the baseline path from a CLI flag or the project config.
+ *
+ * A relative baseline in the config resolves against the config file's
+ * directory, so commands behave the same from any subdirectory.
+ *
+ * @param flagValue - The --baseline (or --output) value, if given.
+ * @param project - The loaded project config, if any.
+ * @returns The resolved baseline path, or undefined if neither source has one.
+ */
+export function resolveBaselinePath(
+  flagValue: string | undefined,
+  project: LoadedProjectConfig | null,
+): string | undefined {
+  if (flagValue) {
+    return flagValue;
+  }
+  if (project?.config.baseline) {
+    return resolveProjectPath(project, project.config.baseline);
+  }
+  return undefined;
+}

--- a/packages/cli/src/transport.test.ts
+++ b/packages/cli/src/transport.test.ts
@@ -2,7 +2,13 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { Command } from "commander";
 import { describe, expect, it } from "vitest";
-import { addTransportOptions, parseHeaders, resolveTransport } from "./transport.js";
+import {
+  addTransportOptions,
+  extractTransportOptions,
+  hasTransportFlags,
+  parseHeaders,
+  resolveTransport,
+} from "./transport.js";
 
 describe("resolveTransport", () => {
   it("resolves --command to stdio transport", () => {
@@ -174,5 +180,55 @@ describe("addTransportOptions", () => {
     const cmd = new Command("test");
     const result = addTransportOptions(cmd);
     expect(result).toBe(cmd);
+  });
+});
+
+describe("extractTransportOptions", () => {
+  it("extracts all transport fields from a parsed options record", () => {
+    const options = {
+      command: "node",
+      args: ["server.js"],
+      env: ["A=b"],
+      url: "http://localhost:3000",
+      sse: true,
+      header: ["X: y"],
+      config: "./mcp.json",
+      server: "alpha",
+      baseline: "ignored.mcpc.json",
+    };
+    expect(extractTransportOptions(options)).toEqual({
+      command: "node",
+      args: ["server.js"],
+      env: ["A=b"],
+      url: "http://localhost:3000",
+      sse: true,
+      header: ["X: y"],
+      config: "./mcp.json",
+      server: "alpha",
+    });
+  });
+
+  it("leaves absent fields undefined", () => {
+    const extracted = extractTransportOptions({ severity: "safe" });
+    expect(extracted.command).toBeUndefined();
+    expect(extracted.sse).toBeUndefined();
+  });
+});
+
+describe("hasTransportFlags", () => {
+  it("returns false for empty options", () => {
+    expect(hasTransportFlags(extractTransportOptions({}))).toBe(false);
+    expect(hasTransportFlags(extractTransportOptions({ baseline: "b.mcpc.json" }))).toBe(false);
+  });
+
+  it("returns true when any transport flag is set", () => {
+    expect(hasTransportFlags(extractTransportOptions({ command: "node" }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ url: "http://x" }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ config: "./mcp.json" }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ args: ["a"] }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ env: ["A=b"] }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ sse: true }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ header: ["X: y"] }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ server: "alpha" }))).toBe(true);
   });
 });

--- a/packages/cli/src/transport.ts
+++ b/packages/cli/src/transport.ts
@@ -89,6 +89,48 @@ export function resolveTransport(options: TransportOptions): ResolvedTransport {
 }
 
 /**
+ * Extracts the transport-related fields from parsed Commander options.
+ *
+ * @param options - The raw parsed options record from a command action.
+ * @returns The typed transport options.
+ */
+export function extractTransportOptions(options: Record<string, unknown>): TransportOptions {
+  return {
+    command: options["command"] as string | undefined,
+    url: options["url"] as string | undefined,
+    config: options["config"] as string | undefined,
+    server: options["server"] as string | undefined,
+    args: options["args"] as string[] | undefined,
+    env: options["env"] as string[] | undefined,
+    sse: options["sse"] === true ? true : undefined,
+    header: options["header"] as string[] | undefined,
+  };
+}
+
+/**
+ * Checks whether any transport flag was passed on the command line.
+ *
+ * Used to decide between CLI flags and the project config's server block —
+ * any transport flag means the config's server block is ignored entirely,
+ * so the two sources are never partially merged.
+ *
+ * @param options - The extracted transport options.
+ * @returns True if at least one transport flag is set.
+ */
+export function hasTransportFlags(options: TransportOptions): boolean {
+  return (
+    options.command !== undefined ||
+    options.url !== undefined ||
+    options.config !== undefined ||
+    options.server !== undefined ||
+    options.args !== undefined ||
+    options.env !== undefined ||
+    options.sse !== undefined ||
+    options.header !== undefined
+  );
+}
+
+/**
  * Adds the standard transport options to a Commander command.
  *
  * Avoids repeating the option calls across commands that need

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,5 +1,20 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import type { Command } from "commander";
+
+/**
+ * Resolves the root program options from a possibly nested subcommand.
+ *
+ * @param cmd - The current Command instance.
+ * @returns The root program's parsed options.
+ */
+export function getRootOpts(cmd: Command): Record<string, unknown> {
+  let current: Command = cmd;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}
 
 /** Output format for CLI commands. */
 export type OutputFormat = "terminal" | "json" | "markdown";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "tsup": "^8.0.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,22 @@ export {
   formatGraphTerminal,
 } from "./graph-format.js";
 export { computeContentHash, sortKeys } from "./hash.js";
+export type {
+  ProjectConfig,
+  ProjectServer,
+  ProjectServerCommand,
+  ProjectServerConfigRef,
+  ProjectServerUrl,
+  ProjectWatchSettings,
+} from "./project-config.js";
+export {
+  isProjectServerCommand,
+  isProjectServerConfigRef,
+  isProjectServerUrl,
+  PROJECT_CONFIG_FILENAME,
+  parseProjectConfig,
+  projectConfigSchema,
+} from "./project-config.js";
 export {
   detectKeyAlgorithm,
   parseSignatureFile,

--- a/packages/core/src/project-config.test.ts
+++ b/packages/core/src/project-config.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  isProjectServerCommand,
+  isProjectServerConfigRef,
+  isProjectServerUrl,
+  PROJECT_CONFIG_FILENAME,
+  parseProjectConfig,
+} from "./project-config.js";
+
+describe("parseProjectConfig", () => {
+  it("accepts an empty config", () => {
+    expect(parseProjectConfig({})).toEqual({});
+  });
+
+  it("accepts a full command-based config", () => {
+    const config = parseProjectConfig({
+      server: { command: "node", args: ["dist/index.js"], env: { API_KEY: "secret" } },
+      baseline: "contracts/baseline.mcpc.json",
+      failOn: "breaking",
+      watch: { paths: ["src"], debounce: 500 },
+    });
+    expect(config.baseline).toBe("contracts/baseline.mcpc.json");
+    expect(config.failOn).toBe("breaking");
+    expect(config.watch).toEqual({ paths: ["src"], debounce: 500 });
+    expect(config.server).toEqual({
+      command: "node",
+      args: ["dist/index.js"],
+      env: { API_KEY: "secret" },
+    });
+  });
+
+  it("accepts a url-based server with sse and headers", () => {
+    const config = parseProjectConfig({
+      server: {
+        url: "http://localhost:3000/mcp",
+        sse: true,
+        headers: { Authorization: "Bearer x" },
+      },
+    });
+    expect(config.server).toEqual({
+      url: "http://localhost:3000/mcp",
+      sse: true,
+      headers: { Authorization: "Bearer x" },
+    });
+  });
+
+  it("accepts a config-reference server with a name", () => {
+    const config = parseProjectConfig({
+      server: { config: "./mcp.json", name: "my-server" },
+    });
+    expect(config.server).toEqual({ config: "./mcp.json", name: "my-server" });
+  });
+
+  it("accepts a baseline-only config", () => {
+    expect(parseProjectConfig({ baseline: "contracts/baseline.mcpc.json" })).toEqual({
+      baseline: "contracts/baseline.mcpc.json",
+    });
+  });
+
+  it("rejects non-object data", () => {
+    expect(() => parseProjectConfig("nope")).toThrow(/Invalid project config/);
+    expect(() => parseProjectConfig(null)).toThrow(/Invalid project config/);
+    expect(() => parseProjectConfig([])).toThrow(/Invalid project config/);
+  });
+
+  it("rejects unknown top-level keys, naming the key", () => {
+    expect(() => parseProjectConfig({ failon: "breaking" })).toThrow(/failon/);
+  });
+
+  it("rejects unknown keys inside server", () => {
+    expect(() => parseProjectConfig({ server: { command: "node", cmd: "node" } })).toThrow(/cmd/);
+  });
+
+  it("rejects unknown keys inside watch", () => {
+    expect(() => parseProjectConfig({ watch: { path: ["src"] } })).toThrow(/path/);
+  });
+
+  it("rejects a server with no transport", () => {
+    expect(() => parseProjectConfig({ server: {} })).toThrow(
+      /exactly one of "command", "url", or "config"/,
+    );
+  });
+
+  it("rejects a server with multiple transports", () => {
+    expect(() =>
+      parseProjectConfig({ server: { command: "node", url: "http://localhost:3000" } }),
+    ).toThrow(/exactly one of "command", "url", or "config"/);
+  });
+
+  it("rejects args without command", () => {
+    expect(() =>
+      parseProjectConfig({ server: { url: "http://localhost:3000", args: ["x"] } }),
+    ).toThrow(/"server.args": "args" is only valid with "command"/);
+  });
+
+  it("rejects env without command", () => {
+    expect(() => parseProjectConfig({ server: { config: "./mcp.json", env: { A: "b" } } })).toThrow(
+      /"env" is only valid with "command"/,
+    );
+  });
+
+  it("rejects sse and headers without url", () => {
+    expect(() => parseProjectConfig({ server: { command: "node", sse: true } })).toThrow(
+      /"sse" is only valid with "url"/,
+    );
+    expect(() => parseProjectConfig({ server: { command: "node", headers: {} } })).toThrow(
+      /"headers" is only valid with "url"/,
+    );
+  });
+
+  it("rejects name without config", () => {
+    expect(() => parseProjectConfig({ server: { command: "node", name: "x" } })).toThrow(
+      /"name" is only valid with "config"/,
+    );
+  });
+
+  it("rejects an invalid failOn value", () => {
+    expect(() => parseProjectConfig({ failOn: "fatal" })).toThrow(/failOn/);
+  });
+
+  it("rejects an empty baseline", () => {
+    expect(() => parseProjectConfig({ baseline: "" })).toThrow(/baseline/);
+  });
+
+  it("rejects invalid watch settings", () => {
+    expect(() => parseProjectConfig({ watch: { paths: [] } })).toThrow(/paths/);
+    expect(() => parseProjectConfig({ watch: { debounce: -1 } })).toThrow(/debounce/);
+    expect(() => parseProjectConfig({ watch: { debounce: 1.5 } })).toThrow(/debounce/);
+  });
+
+  it("reports multiple issues in one message", () => {
+    const attempt = () => parseProjectConfig({ failOn: "fatal", baseline: "" });
+    expect(attempt).toThrow(/failOn/);
+    expect(attempt).toThrow(/baseline/);
+  });
+});
+
+describe("ProjectServer type guards", () => {
+  it("discriminate the three variants", () => {
+    const command = { command: "node" };
+    const url = { url: "http://localhost:3000" };
+    const configRef = { config: "./mcp.json" };
+
+    expect(isProjectServerCommand(command)).toBe(true);
+    expect(isProjectServerCommand(url)).toBe(false);
+    expect(isProjectServerUrl(url)).toBe(true);
+    expect(isProjectServerUrl(configRef)).toBe(false);
+    expect(isProjectServerConfigRef(configRef)).toBe(true);
+    expect(isProjectServerConfigRef(command)).toBe(false);
+  });
+});
+
+describe("PROJECT_CONFIG_FILENAME", () => {
+  it("is mcpcontracts.json", () => {
+    expect(PROJECT_CONFIG_FILENAME).toBe("mcpcontracts.json");
+  });
+});

--- a/packages/core/src/project-config.ts
+++ b/packages/core/src/project-config.ts
@@ -1,0 +1,185 @@
+/**
+ * mcpcontracts.json project config: types, schema, and validation.
+ *
+ * The project config file lets repeated CLI invocations (locally and in CI)
+ * omit transport and baseline flags. This module only defines the format and
+ * validates parsed JSON data — file discovery and reading live in the CLI.
+ */
+
+import { z } from "zod/v4";
+import type { Severity } from "./diff-types.js";
+
+/** File name of the project config, discovered by walking up from the CWD. */
+export const PROJECT_CONFIG_FILENAME = "mcpcontracts.json";
+
+/** Server reached by spawning a command over stdio. */
+export interface ProjectServerCommand {
+  /** Executable to run (e.g. "node"). */
+  command: string;
+  /** Arguments for the command. */
+  args?: string[];
+  /** Environment variables for the spawned process. */
+  env?: Record<string, string>;
+}
+
+/** Server reached over streamable-http or SSE. */
+export interface ProjectServerUrl {
+  /** Server URL. */
+  url: string;
+  /** Use SSE transport instead of streamable-http. */
+  sse?: boolean;
+  /** Custom HTTP headers. */
+  headers?: Record<string, string>;
+}
+
+/** Server defined in an external mcp.json config file. */
+export interface ProjectServerConfigRef {
+  /** Path to the mcp.json file, relative to the project config. */
+  config: string;
+  /** Server name to select when the config defines several. */
+  name?: string;
+}
+
+/** One of the three ways to reach the server. */
+export type ProjectServer = ProjectServerCommand | ProjectServerUrl | ProjectServerConfigRef;
+
+/** Watch-mode settings. */
+export interface ProjectWatchSettings {
+  /** Paths to watch for changes. */
+  paths?: string[];
+  /** Debounce interval in milliseconds. */
+  debounce?: number;
+}
+
+/** Parsed mcpcontracts.json contents. */
+export interface ProjectConfig {
+  /** How to reach the MCP server. */
+  server?: ProjectServer;
+  /** Path to the baseline snapshot, relative to the project config. */
+  baseline?: string;
+  /** Severity threshold that triggers exit code 1. */
+  failOn?: Severity;
+  /** Watch-mode settings. */
+  watch?: ProjectWatchSettings;
+}
+
+const serverSchema = z
+  .strictObject({
+    command: z.string().min(1).optional(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    url: z.string().min(1).optional(),
+    sse: z.boolean().optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    config: z.string().min(1).optional(),
+    name: z.string().min(1).optional(),
+  })
+  .superRefine((server, ctx) => {
+    const transports = [server.command, server.url, server.config].filter(
+      (v) => v !== undefined,
+    ).length;
+    if (transports !== 1) {
+      ctx.addIssue({
+        code: "custom",
+        message: 'specify exactly one of "command", "url", or "config"',
+      });
+    }
+    const requires: Array<[unknown, string, string]> = [
+      [server.args, "args", "command"],
+      [server.env, "env", "command"],
+      [server.sse, "sse", "url"],
+      [server.headers, "headers", "url"],
+      [server.name, "name", "config"],
+    ];
+    for (const [value, key, owner] of requires) {
+      if (value !== undefined && server[owner as "command" | "url" | "config"] === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: `"${key}" is only valid with "${owner}"`,
+          path: [key],
+        });
+      }
+    }
+  });
+
+const watchSchema = z.strictObject({
+  paths: z.array(z.string().min(1)).min(1).optional(),
+  debounce: z.number().int().positive().optional(),
+});
+
+const projectConfigSchemaInternal = z.strictObject({
+  server: serverSchema.optional(),
+  baseline: z.string().min(1).optional(),
+  failOn: z.enum(["safe", "warning", "breaking"]).optional(),
+  watch: watchSchema.optional(),
+});
+
+/**
+ * Zod schema for mcpcontracts.json.
+ *
+ * The runtime refinements guarantee the `ProjectServer` union invariant
+ * (exactly one transport key), which the inferred type cannot express.
+ */
+export const projectConfigSchema =
+  projectConfigSchemaInternal as unknown as z.ZodType<ProjectConfig>;
+
+/**
+ * Formats a single zod issue as "path: message".
+ *
+ * @param issue - The zod issue to format.
+ * @returns A human-readable description naming the offending key.
+ */
+function formatIssue(issue: z.core.$ZodIssue): string {
+  if (issue.path.length === 0) {
+    return issue.message;
+  }
+  return `"${issue.path.join(".")}": ${issue.message}`;
+}
+
+/**
+ * Validates parsed JSON data as a project config.
+ *
+ * Unknown keys are an error, so typos like "failon" are caught instead of
+ * silently ignored.
+ *
+ * @param data - Parsed JSON data (e.g. from an mcpcontracts.json file).
+ * @returns The validated ProjectConfig.
+ */
+export function parseProjectConfig(data: unknown): ProjectConfig {
+  const result = projectConfigSchemaInternal.safeParse(data);
+  if (!result.success) {
+    const details = result.error.issues.map(formatIssue).join("; ");
+    throw new Error(`Invalid project config: ${details}`);
+  }
+  return result.data as ProjectConfig;
+}
+
+/**
+ * Narrows a ProjectServer to the stdio command variant.
+ *
+ * @param server - The server block to test.
+ * @returns True if the server is reached by spawning a command.
+ */
+export function isProjectServerCommand(server: ProjectServer): server is ProjectServerCommand {
+  return "command" in server && server.command !== undefined;
+}
+
+/**
+ * Narrows a ProjectServer to the URL variant.
+ *
+ * @param server - The server block to test.
+ * @returns True if the server is reached over HTTP/SSE.
+ */
+export function isProjectServerUrl(server: ProjectServer): server is ProjectServerUrl {
+  return "url" in server && server.url !== undefined;
+}
+
+/**
+ * Narrows a ProjectServer to the mcp.json reference variant.
+ *
+ * @param server - The server block to test.
+ * @returns True if the server is defined in an external mcp.json file.
+ */
+export function isProjectServerConfigRef(server: ProjectServer): server is ProjectServerConfigRef {
+  return "config" in server && server.config !== undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,10 @@ importers:
         version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
 
   packages/core:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^25.5.0


### PR DESCRIPTION
## Summary

Adds project-level configuration via `mcpcontracts.json`, discovered by walking up from the CWD (like `tsconfig.json`) or passed explicitly with the new global `--project <path>` option. Repeated invocations no longer need to re-state transport and baseline flags:

```bash
mcpdiff baseline update        # knows the server + baseline path
mcpdiff ci                     # zero flags in CI
mcpdiff watch                  # zero flags in dev
```

## Implementation

- **core** (`project-config.ts`): `ProjectConfig` types + zod schema (strict objects — unknown keys are errors, catching typos like `"failon"`; exactly-one-transport rule for the `server` block) and `parseProjectConfig()`. Validation is pure data-in/data-out; core stays network/fs-free. Adds `zod@^3.25.76` (v4 API via `zod/v4`), matching the version already resolved by the MCP SDK.
- **cli** (`project-config.ts`): discovery, loading (invalid config → exit `2` with a message naming the file and offending key, even when flags would override it), and precedence helpers. Relative paths in the config (`baseline`, `watch.paths`, `server.config`) resolve against the config file's directory, and config-sourced stdio servers spawn with that directory as cwd, so commands behave identically from any subdirectory.
- **Precedence:** explicit flags > config file > defaults. Any transport flag ignores the config's `server` block entirely — no partial merging. `ci`/`watch` lost their commander-level defaults for `--baseline`/`--fail-on` (etc.) so the config can supply them; behavior without a config is unchanged, including exit codes.
- Wired into all live-server commands: `snapshot`, `diff --live`, `baseline update`, `baseline verify`, `ci`, `watch`. Pure file commands are unaffected.
- Deduplicated the transport-option extraction previously copied across six commands (`extractTransportOptions`/`hasTransportFlags`).

## Testing

- Unit tests for the schema (core) and discovery/loading/precedence (cli)
- `execa`-style integration tests against a fixture stdio MCP server, covering zero-flag `baseline update`/`verify`/`ci`, discovery from subdirectories, `--project`, flag override, and invalid-config exit codes
- Verified end-to-end against `example-contact-server` (matching `feat/project-config` branch there adds its `mcpcontracts.json`)

Closes #57
