### PR TITLE
Consolidate baseline comparison into check and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ MCP servers expose tools, resources, and prompts to AI agents. These interfaces 
 
 ```bash
 # Capture a baseline snapshot of your MCP server
-npx @mcp-contracts/cli baseline update --command "node ./my-server/dist/index.js"
+npx @mcp-contracts/cli update --command "node ./my-server/dist/index.js"
 # → writes contracts/baseline.mcpc.json
 
-# Later, verify nothing has changed
-npx @mcp-contracts/cli baseline verify --command "node ./my-server/dist/index.js"
+# Later, check nothing has changed (locally, in CI, anywhere)
+npx @mcp-contracts/cli check --command "node ./my-server/dist/index.js"
 
 # Or diff two snapshots manually
 npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v1.mcpc.json
@@ -33,7 +33,7 @@ npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v2
 npx @mcp-contracts/cli diff v1.mcpc.json v2.mcpc.json
 ```
 
-Tired of repeating `--command`? Put it in a [project config](#project-config-mcpcontractsjson) once and run `mcpdiff baseline verify` with zero flags.
+Tired of repeating `--command`? Put it in a [project config](#project-config-mcpcontractsjson) once and run `mcpdiff check` with zero flags.
 
 Output:
 ```
@@ -47,6 +47,8 @@ Output:
 ```
 
 ## Commands
+
+> Migrating from an older version? `ci`, `watch`, `baseline verify`, `baseline update`, and `diff --live` still work but are deprecated — they are replaced by `check` (with `--watch`) and `update`, and will be removed in a future release.
 
 ### `mcpdiff snapshot`
 
@@ -72,9 +74,6 @@ Compares two snapshots and classifies every change as breaking, warning, or safe
 
 ```bash
 mcpdiff diff before.mcpc.json after.mcpc.json
-
-# Diff a baseline against a live server
-mcpdiff diff baseline.mcpc.json --live --command "node server.js"
 
 # Fail CI on warnings too (stricter)
 mcpdiff diff before.mcpc.json after.mcpc.json --fail-on warning
@@ -119,57 +118,53 @@ mcpdiff --format mermaid graph --config ./mcp.json
 mcpdiff --format dot graph --config ./mcp.json
 ```
 
-### `mcpdiff baseline`
+### `mcpdiff check`
 
-Manage contract baselines — capture and verify snapshots against a committed baseline.
-
-```bash
-# Capture a baseline (default: contracts/baseline.mcpc.json)
-mcpdiff baseline update --command "node server.js"
-
-# Write to a custom path
-mcpdiff -o custom/path.mcpc.json baseline update --command "node server.js"
-
-# Verify the server still matches the baseline
-mcpdiff baseline verify --command "node server.js"
-mcpdiff baseline verify --baseline custom/path.mcpc.json --url http://localhost:3000/mcp
-```
-
-### `mcpdiff ci`
-
-All-in-one CI command: captures a snapshot, diffs against a baseline, outputs the report, and sets the exit code.
+The one command for "does the live server still match the baseline": captures a snapshot, diffs it against the baseline, reports, and sets the exit code. Works the same locally, in CI, and in watch mode.
 
 ```bash
-# Basic usage
-mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js"
+# Check against the default baseline (contracts/baseline.mcpc.json)
+mcpdiff check --command "node server.js"
+
+# With a project config, zero flags
+mcpdiff check
 
 # Fail on warnings too (stricter)
-mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --fail-on warning
+mcpdiff check --fail-on warning
 
 # Only show breaking changes
-mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --severity breaking
+mcpdiff check --severity breaking
+
+# Re-run on file changes during development
+mcpdiff check --watch --watch-paths src --debounce 1000
+
+# Require a valid signature on the baseline before diffing
+mcpdiff check --verify-signature --signature-key ./public.pem
 
 # Send results to a webhook
-mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --webhook https://example.com/hook
+mcpdiff check --webhook https://example.com/hook
 ```
 
-Auto-detects CI environments (GitHub Actions, GitLab CI, CircleCI) and selects the appropriate output format. Writes to `GITHUB_STEP_SUMMARY` when running in GitHub Actions.
+Auto-detects CI environments (GitHub Actions, GitLab CI, CircleCI) and selects the appropriate output format. Writes to `GITHUB_STEP_SUMMARY` when running in GitHub Actions. When the live contract is unchanged (matching content hashes), the diff engine is skipped entirely.
 
-### `mcpdiff watch`
+**Exit codes:** `0` = clean, `1` = changes at or above the `--fail-on` threshold, `2` = error.
 
-Watch for file changes and re-diff against a baseline on every change. Useful during development.
+### `mcpdiff update`
+
+Captures the live server and writes the baseline. The counterpart to `check`.
 
 ```bash
-mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js"
+# Write the default baseline (contracts/baseline.mcpc.json)
+mcpdiff update --command "node server.js"
 
-# Watch specific paths with custom debounce
-mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js" \
-  --watch-paths src lib --debounce 1000
+# With a project config, zero flags
+mcpdiff update
 
-# Send diffs to a webhook on each cycle
-mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js" \
-  --webhook https://example.com/hook
+# Write to a custom path
+mcpdiff update --baseline custom/path.mcpc.json --command "node server.js"
 ```
+
+For ad-hoc snapshots that are not baselines, use `mcpdiff snapshot -o <file>`.
 
 ### `mcpdiff sign`
 
@@ -270,15 +265,14 @@ Instead of repeating transport and baseline flags on every invocation, put them 
 With the config in place, the repeated commands need no flags at all:
 
 ```bash
-mcpdiff baseline update        # knows the server + baseline path
-mcpdiff baseline verify        # zero flags locally
-mcpdiff ci                     # zero flags in CI
-mcpdiff watch                  # zero flags in dev
+mcpdiff update                 # knows the server + baseline path
+mcpdiff check                  # zero flags locally and in CI
+mcpdiff check --watch          # zero flags in dev
 ```
 
-The config is read by every command that connects to a live server: `snapshot`, `diff --live`, `baseline update`, `baseline verify`, `ci`, and `watch`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`, `verify-hash`) ignore it.
+The config is read by every command that connects to a live server: `check`, `update`, and `snapshot`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`, `verify-hash`) ignore it.
 
-**Precedence:** explicit CLI flags > config file > built-in defaults. Passing any transport flag (`--command`, `--url`, `--config`, …) ignores the config's `server` block entirely — the two sources are never partially merged. `failOn` applies to `ci` and `watch`; the `watch` block applies to `watch` only.
+**Precedence:** explicit CLI flags > config file > built-in defaults. Passing any transport flag (`--command`, `--url`, `--config`, …) ignores the config's `server` block entirely — the two sources are never partially merged. `failOn` and the `watch` block apply to `check`.
 
 **Paths** in the config (`baseline`, `watch.paths`, `server.config`) are resolved relative to the config file's directory, so commands behave the same from any subdirectory.
 
@@ -321,7 +315,7 @@ jobs:
 
 ### CLI in CI
 
-Use `mcpdiff ci` directly in any CI system:
+Use `mcpdiff check` directly in any CI system:
 
 ```yaml
 # .github/workflows/mcp-contract.yml
@@ -333,18 +327,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g @mcp-contracts/cli
-      - run: mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node dist/index.js"
+      - run: mcpdiff check --baseline contracts/baseline.mcpc.json --command "node dist/index.js"
+
+      # Or with a committed mcpcontracts.json, zero flags
+      - run: mcpdiff check
 
       # Or with signature verification
       - run: >
-          mcpdiff ci
+          mcpdiff check
           --baseline contracts/baseline.mcpc.json
           --command "node dist/index.js"
           --verify-signature
           --signature-key ./public.pem
 ```
 
-The `ci` command auto-detects the CI environment and selects the right output format (markdown for GitHub Actions, JSON otherwise). It also writes to `GITHUB_STEP_SUMMARY` automatically.
+The `check` command auto-detects the CI environment and selects the right output format (markdown for GitHub Actions, JSON otherwise). It also writes to `GITHUB_STEP_SUMMARY` automatically.
 
 ## Packages
 

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -55,14 +55,20 @@ describe("integration: CLI", () => {
   describe("--help", () => {
     it("exits 0 and shows usage info", async () => {
       const { stdout, exitCode } = await runCli("--help");
-      expect(exitCode).toBe(0);
       expect(stdout).toContain("mcpdiff");
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("check");
+      expect(stdout).toContain("update");
       expect(stdout).toContain("snapshot");
       expect(stdout).toContain("diff");
       expect(stdout).toContain("inspect");
-      expect(stdout).toContain("baseline");
-      expect(stdout).toContain("ci");
-      expect(stdout).toContain("watch");
+    });
+
+    it("hides deprecated commands from usage info", async () => {
+      const { stdout } = await runCli("--help");
+      expect(stdout).not.toMatch(/^ {2}ci\b/m);
+      expect(stdout).not.toMatch(/^ {2}watch\b/m);
+      expect(stdout).not.toMatch(/^ {2}baseline\b/m);
     });
   });
 
@@ -401,5 +407,91 @@ describe("integration: project config (mcpcontracts.json)", () => {
     expect(exitCode).toBe(2);
     expect(stderr).toContain("--baseline");
     expect(stderr).toContain("mcpcontracts.json");
+  });
+});
+
+describe("integration: check and update", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "mcpc-check-update-"));
+    writeFileSync(
+      join(projectDir, "mcpcontracts.json"),
+      JSON.stringify(
+        {
+          server: { command: "node", args: [FIXTURE_SERVER] },
+          baseline: "contracts/baseline.mcpc.json",
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("update then check succeed with zero flags", async () => {
+    const update = await runCliIn(projectDir, "update");
+    expect(update.exitCode).toBe(0);
+    expect(update.stderr).toContain("Baseline written to");
+    expect(existsSync(join(projectDir, "contracts", "baseline.mcpc.json"))).toBe(true);
+
+    const check = await runCliIn(projectDir, "check", "--format", "json");
+    expect(check.exitCode).toBe(0);
+    expect(check.stderr).toContain("Contract unchanged");
+    const report = JSON.parse(check.stdout);
+    expect(report.changes).toHaveLength(0);
+  });
+
+  it("check exits 2 when the baseline file is missing", async () => {
+    const { stderr, exitCode } = await runCliIn(projectDir, "check");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("baseline.mcpc.json");
+  });
+
+  it("check --help shows the full consolidated flag surface", async () => {
+    const { stdout, exitCode } = await runCli("check", "--help");
+    expect(exitCode).toBe(0);
+    for (const flag of [
+      "--baseline",
+      "--fail-on",
+      "--severity",
+      "--webhook",
+      "--verify-signature",
+      "--signature-key",
+      "--watch",
+      "--watch-paths",
+      "--debounce",
+      "--clear",
+      "--command",
+      "--url",
+    ]) {
+      expect(stdout).toContain(flag);
+    }
+  });
+
+  it("deprecated spellings still work and print a notice", async () => {
+    await runCliIn(projectDir, "update");
+
+    const baselineVerify = await runCliIn(projectDir, "baseline", "verify");
+    expect(baselineVerify.exitCode).toBe(0);
+    expect(baselineVerify.stderr).toContain("deprecated");
+    expect(baselineVerify.stderr).toContain("mcpdiff check");
+
+    const baselineUpdate = await runCliIn(projectDir, "baseline", "update");
+    expect(baselineUpdate.exitCode).toBe(0);
+    expect(baselineUpdate.stderr).toContain("mcpdiff update");
+
+    const ci = await runCliIn(projectDir, "ci", "--format", "json");
+    expect(ci.exitCode).toBe(0);
+    expect(ci.stderr).toContain("mcpdiff check");
+
+    const diffLive = await runCliIn(projectDir, "diff", "--live", "--format", "json");
+    expect(diffLive.exitCode).toBe(0);
+    expect(diffLive.stderr).toContain("mcpdiff check");
   });
 });

--- a/packages/cli/src/baseline-signature.ts
+++ b/packages/cli/src/baseline-signature.ts
@@ -1,0 +1,85 @@
+/**
+ * Baseline signature verification, shared by `check` and the deprecated `ci`.
+ */
+
+import { readFileSync } from "node:fs";
+import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import { parseSignatureFile, verifySignature } from "@mcp-contracts/core";
+import { deriveSignaturePath } from "./commands/sign.js";
+import { CliExitError } from "./utils.js";
+
+/**
+ * Verifies the baseline snapshot's signature before diffing.
+ *
+ * @param baseline - The parsed baseline snapshot.
+ * @param baselinePath - File path to the baseline (used to derive sig path).
+ * @param signatureKeyOption - The --signature-key option value, if provided.
+ * @param quiet - Whether to suppress non-essential output.
+ */
+export function verifyBaselineSignature(
+  baseline: MCPContractSnapshot,
+  baselinePath: string,
+  signatureKeyOption: string | undefined,
+  quiet: boolean,
+): void {
+  const keyPem = resolveSignatureKey(signatureKeyOption);
+  const sigPath = deriveSignaturePath(baselinePath);
+
+  let sigJson: string;
+  try {
+    sigJson = readFileSync(sigPath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read baseline signature file "${sigPath}": ${message}`);
+  }
+
+  const sig = parseSignatureFile(sigJson);
+  const result = verifySignature(baseline, sig, keyPem);
+
+  if (!result.valid) {
+    process.stderr.write(`Baseline signature verification failed: ${result.error}\n`);
+    throw new CliExitError(2);
+  }
+
+  if (!quiet) {
+    process.stderr.write("Baseline signature verified\n");
+  }
+}
+
+/**
+ * Resolves the public key PEM for signature verification.
+ *
+ * Checks the `--signature-key` option first, then the `MCP_SIGNATURE_KEY`
+ * environment variable. The env var can contain PEM content directly
+ * (starts with "-----BEGIN") or a file path.
+ *
+ * @param optionValue - The --signature-key option value, if provided.
+ * @returns The PEM string for the public key.
+ */
+function resolveSignatureKey(optionValue: string | undefined): string {
+  if (optionValue) {
+    try {
+      return readFileSync(optionValue, "utf-8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to read signature key file "${optionValue}": ${message}`);
+    }
+  }
+
+  const envValue = process.env["MCP_SIGNATURE_KEY"];
+  if (envValue) {
+    if (envValue.startsWith("-----BEGIN")) {
+      return envValue;
+    }
+    try {
+      return readFileSync(envValue, "utf-8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to read key from MCP_SIGNATURE_KEY path "${envValue}": ${message}`);
+    }
+  }
+
+  throw new Error(
+    "--verify-signature requires --signature-key <path> or MCP_SIGNATURE_KEY environment variable",
+  );
+}

--- a/packages/cli/src/commands/baseline.ts
+++ b/packages/cli/src/commands/baseline.ts
@@ -13,6 +13,7 @@ import {
   CliExitError,
   getRootOpts,
   handleErrors,
+  printDeprecationNotice,
   readSnapshotFile,
   writeOutput,
 } from "../utils.js";
@@ -38,6 +39,9 @@ export function createBaselineUpdateCommand(): Command {
     handleErrors(async (options: Record<string, unknown>) => {
       const rootOpts = getRootOpts(cmd);
       const quiet = rootOpts["quiet"] === true;
+      if (!quiet) {
+        printDeprecationNotice("mcpdiff baseline update", "mcpdiff update");
+      }
       const project = loadProjectConfig(rootOpts["project"] as string | undefined);
       const outputPath =
         resolveBaselinePath(rootOpts["output"] as string | undefined, project) ??
@@ -80,6 +84,9 @@ export function createBaselineVerifyCommand(): Command {
       handleErrors(async (options: Record<string, unknown>) => {
         const rootOpts = getRootOpts(cmd);
         const quiet = rootOpts["quiet"] === true;
+        if (!quiet) {
+          printDeprecationNotice("mcpdiff baseline verify", "mcpdiff check");
+        }
         const project = loadProjectConfig(rootOpts["project"] as string | undefined);
         const baselinePath =
           resolveBaselinePath(options["baseline"] as string | undefined, project) ??

--- a/packages/cli/src/commands/baseline.ts
+++ b/packages/cli/src/commands/baseline.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import { diffSnapshots } from "@mcp-contracts/core";
 import { Command } from "commander";
 import {
+  DEFAULT_BASELINE_PATH,
   loadProjectConfig,
   resolveBaselinePath,
   resolveTransportOrProject,
@@ -16,8 +17,6 @@ import {
   writeOutput,
 } from "../utils.js";
 import { captureSnapshot } from "./capture.js";
-
-const DEFAULT_BASELINE_PATH = "contracts/baseline.mcpc.json";
 
 /**
  * Creates the `baseline update` subcommand.

--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -1,0 +1,328 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createSnapshot } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { createCheckCommand } from "./check.js";
+
+/** Creates a snapshot matching the mock captureSnapshot output. */
+function makeMockSnapshot() {
+  return createSnapshot({
+    server: {
+      name: "test-server",
+      version: "1.0.0",
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+    },
+    tools: [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    capture: { transport: "stdio", source: "node", tool: "mcpdiff/0.1.0" },
+  });
+}
+
+vi.mock("./capture.js", () => ({
+  captureSnapshot: vi.fn().mockImplementation(async () => ({
+    snapshot: makeMockSnapshot(),
+    serverName: "test-server",
+    serverVersion: "1.0.0",
+  })),
+}));
+
+const TMP_DIR = resolve(import.meta.dirname, "__tmp_check_test");
+const FIXTURES_DIR = resolve(import.meta.dirname, "../../../core/src/__fixtures__");
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file path")
+    .option("--quiet", "Suppress non-essential output")
+    .option("--verbose", "Show detailed information")
+    .option("--project <path>", "Path to mcpcontracts.json");
+  program.addCommand(createCheckCommand());
+  return program;
+}
+
+/** Creates a baseline snapshot from the mock server data for testing. */
+function createMockBaseline(): string {
+  const snapshot = makeMockSnapshot();
+  const filePath = resolve(TMP_DIR, "baseline.mcpc.json");
+  writeFileSync(filePath, JSON.stringify(snapshot, null, 2), "utf-8");
+  return filePath;
+}
+
+describe("check command", () => {
+  let stdoutData: string;
+  let stderrData: string;
+  let exitCode: number | undefined;
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+  let exitSpy: MockInstance;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    stdoutData = "";
+    stderrData = "";
+    exitCode = undefined;
+    originalEnv = { ...process.env };
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutData += String(chunk);
+      return true;
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+    mkdirSync(TMP_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    process.env = originalEnv;
+    if (existsSync(TMP_DIR)) {
+      rmSync(TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("registers with all expected options", () => {
+    const program = createProgram();
+    const checkCmd = program.commands.find((c) => c.name() === "check");
+    expect(checkCmd).toBeDefined();
+
+    const optionNames = checkCmd?.options.map((o) => o.long) ?? [];
+    for (const opt of [
+      "--baseline",
+      "--fail-on",
+      "--severity",
+      "--webhook",
+      "--verify-signature",
+      "--signature-key",
+      "--watch",
+      "--watch-paths",
+      "--debounce",
+      "--clear",
+      "--command",
+      "--args",
+      "--url",
+      "--sse",
+      "--header",
+      "--config",
+      "--server",
+      "--env",
+    ]) {
+      expect(optionNames).toContain(opt);
+    }
+  });
+
+  it("exits 0 and reports no changes with a matching baseline", async () => {
+    const baselinePath = createMockBaseline();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+    ]);
+    const report = JSON.parse(stdoutData);
+    expect(report.changes).toHaveLength(0);
+    expect(report.summary.breaking).toBe(0);
+    expect(exitCode).toBeUndefined();
+    expect(stderrData).toContain("Contract unchanged");
+  });
+
+  it("exits 1 when breaking changes exceed the default threshold", async () => {
+    const baselinePath = resolve(FIXTURES_DIR, "server-v1.mcpc.json");
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "--format",
+        "json",
+        "check",
+        "--baseline",
+        baselinePath,
+        "--command",
+        "node",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it("exits 0 with matching baseline even with --fail-on safe", async () => {
+    const baselinePath = createMockBaseline();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+      "--fail-on",
+      "safe",
+    ]);
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("respects --severity for display filtering", async () => {
+    const baselinePath = resolve(FIXTURES_DIR, "server-v1.mcpc.json");
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "--format",
+        "json",
+        "check",
+        "--baseline",
+        baselinePath,
+        "--command",
+        "node",
+        "--severity",
+        "breaking",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    const report = JSON.parse(stdoutData);
+    expect(report.changes.length).toBeGreaterThan(0);
+    for (const change of report.changes) {
+      expect(change.severity).toBe("breaking");
+    }
+  });
+
+  it("uses CI-suggested format when no explicit --format", async () => {
+    const baselinePath = createMockBaseline();
+    process.env.GITHUB_ACTIONS = "true";
+    process.env.GITHUB_STEP_SUMMARY = "";
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+    ]);
+    // GitHub Actions suggests markdown format
+    expect(stdoutData).toContain("#");
+  });
+
+  it("writes to GITHUB_STEP_SUMMARY when in GitHub Actions", async () => {
+    const baselinePath = createMockBaseline();
+    const summaryPath = resolve(TMP_DIR, "step-summary.md");
+    writeFileSync(summaryPath, "", "utf-8");
+
+    process.env.GITHUB_ACTIONS = "true";
+    process.env.GITHUB_STEP_SUMMARY = summaryPath;
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+    ]);
+    const summaryContent = readFileSync(summaryPath, "utf-8");
+    expect(summaryContent.length).toBeGreaterThan(0);
+    expect(summaryContent).toContain("#");
+  });
+
+  it("defaults to contracts/baseline.mcpc.json when no baseline is given", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "check", "--command", "node"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("contracts/baseline.mcpc.json");
+  });
+
+  it("errors if no transport specified", async () => {
+    const baselinePath = createMockBaseline();
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "check", "--baseline", baselinePath]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Specify one of");
+  });
+
+  it("warns on webhook failure without affecting exit code", async () => {
+    const baselinePath = createMockBaseline();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+      "--webhook",
+      "http://localhost:1/unreachable",
+    ]);
+    expect(exitCode).toBeUndefined();
+    expect(stderrData).toContain("Warning: Webhook failed");
+  });
+
+  it("requires a key for --verify-signature", async () => {
+    const baselinePath = createMockBaseline();
+    delete process.env.MCP_SIGNATURE_KEY;
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "check",
+        "--baseline",
+        baselinePath,
+        "--command",
+        "node",
+        "--verify-signature",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("--signature-key");
+  });
+});

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -36,7 +36,7 @@ import { resolveWatchOptions } from "./watch.js";
  * @param explicitFormat - The --format value, if given.
  * @returns The resolved output format.
  */
-function resolveCheckFormat(explicitFormat: string | undefined): OutputFormat {
+export function resolveCheckFormat(explicitFormat: string | undefined): OutputFormat {
   if (explicitFormat) {
     return resolveFormat(explicitFormat);
   }
@@ -55,7 +55,7 @@ function resolveCheckFormat(explicitFormat: string | undefined): OutputFormat {
  * @param noColor - Strip ANSI colors from terminal output.
  * @returns The formatted report string.
  */
-function formatReport(report: DiffReport, format: OutputFormat, noColor: boolean): string {
+export function formatReport(report: DiffReport, format: OutputFormat, noColor: boolean): string {
   let output: string;
   if (format === "json") {
     output = formatJson(report);

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,0 +1,187 @@
+import { appendFileSync } from "node:fs";
+import type { DiffReport } from "@mcp-contracts/core";
+import {
+  createEmptyDiffReport,
+  createWebhookPayload,
+  diffSnapshots,
+  formatJson,
+  formatMarkdown,
+  formatTerminal,
+  SEVERITY_ORDER,
+} from "@mcp-contracts/core";
+import { Command } from "commander";
+import { verifyBaselineSignature } from "../baseline-signature.js";
+import { detectCIEnvironment } from "../ci-env.js";
+import { loadProjectConfig, resolveTransportOrProject } from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import {
+  CliExitError,
+  getRootOpts,
+  handleErrors,
+  type OutputFormat,
+  readSnapshotFile,
+  resolveFormat,
+  stripAnsi,
+  writeOutput,
+} from "../utils.js";
+import { runWatchLoop } from "../watch-loop.js";
+import { sendWebhook } from "../webhook.js";
+import { captureSnapshot } from "./capture.js";
+import { resolveWatchOptions } from "./watch.js";
+
+/**
+ * Resolves the output format: explicit --format wins, then the CI
+ * environment's suggestion, then TTY detection.
+ *
+ * @param explicitFormat - The --format value, if given.
+ * @returns The resolved output format.
+ */
+function resolveCheckFormat(explicitFormat: string | undefined): OutputFormat {
+  if (explicitFormat) {
+    return resolveFormat(explicitFormat);
+  }
+  const ciEnv = detectCIEnvironment();
+  if (ciEnv.isCI) {
+    return ciEnv.suggestedFormat as OutputFormat;
+  }
+  return resolveFormat(undefined);
+}
+
+/**
+ * Formats a diff report in the requested output format.
+ *
+ * @param report - The diff report to format.
+ * @param format - The output format.
+ * @param noColor - Strip ANSI colors from terminal output.
+ * @returns The formatted report string.
+ */
+function formatReport(report: DiffReport, format: OutputFormat, noColor: boolean): string {
+  let output: string;
+  if (format === "json") {
+    output = formatJson(report);
+  } else if (format === "markdown") {
+    output = formatMarkdown(report);
+  } else {
+    output = formatTerminal(report);
+  }
+  if (noColor && format === "terminal") {
+    output = stripAnsi(output);
+  }
+  return output;
+}
+
+/**
+ * Creates the `check` subcommand for the mcpdiff CLI.
+ *
+ * The one command for "does the live server still match the baseline":
+ * captures a snapshot, diffs it against the baseline, reports, and sets the
+ * exit code. Detects CI environments, optionally verifies the baseline
+ * signature, and re-runs on file changes with --watch.
+ *
+ * @returns A Commander Command instance for the check subcommand.
+ */
+export function createCheckCommand(): Command {
+  const cmd = new Command("check").description("Verify the live server still matches the baseline");
+
+  addTransportOptions(cmd);
+
+  cmd
+    .option("--baseline <path>", "Path to baseline snapshot")
+    .option("--fail-on <level>", 'Severity threshold for exit code 1 (default: "breaking")')
+    .option("--severity <level>", "Minimum severity to display", "safe")
+    .option("--webhook <url>", "POST diff results to a webhook URL")
+    .option("--verify-signature", "Require valid signature on baseline before diffing")
+    .option("--signature-key <path>", "Path to public key for signature verification")
+    .option("--watch", "Re-run the check on file changes")
+    .option("--watch-paths <paths...>", 'Paths to watch with --watch (default: ".")')
+    .option("--debounce <ms>", "Debounce interval for --watch in milliseconds (default: 500)")
+    .option("--clear", "Clear screen between --watch cycles")
+    .action(
+      handleErrors(async (options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const quiet = rootOpts["quiet"] === true;
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+
+        // Shared flags > config > defaults resolution with the watch command.
+        const { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear } =
+          resolveWatchOptions(options, project);
+
+        const baseline = readSnapshotFile(baselinePath);
+
+        if (options["verifySignature"] === true) {
+          verifyBaselineSignature(
+            baseline,
+            baselinePath,
+            options["signatureKey"] as string | undefined,
+            quiet,
+          );
+        }
+
+        const transport = resolveTransportOrProject(options, project);
+
+        if (options["watch"] === true) {
+          await runWatchLoop({
+            transport,
+            baselinePath,
+            watchPaths,
+            debounceMs,
+            minSeverity: severity,
+            failOn,
+            webhookUrl,
+            shouldClear,
+            quiet,
+          });
+          return;
+        }
+
+        const { snapshot: current } = await captureSnapshot({ transport, quiet });
+
+        // Fast path from the absorbed `baseline verify`: freshly captured
+        // snapshots hash honestly, so a matching hash means no changes and
+        // the diff engine can be skipped.
+        const unchanged = baseline.contentHash === current.contentHash;
+        const report = unchanged
+          ? createEmptyDiffReport(baseline, current)
+          : diffSnapshots(baseline, current, { minSeverity: severity });
+
+        const format = resolveCheckFormat(rootOpts["format"] as string | undefined);
+        const noColor = rootOpts["color"] === false;
+        const output = formatReport(report, format, noColor);
+        writeOutput(`${output}\n`, rootOpts["output"] as string | undefined);
+
+        if (unchanged && !quiet) {
+          process.stderr.write("Contract unchanged\n");
+        }
+
+        // GitHub Actions step summary
+        const ciEnv = detectCIEnvironment();
+        if (ciEnv.stepSummaryPath) {
+          appendFileSync(ciEnv.stepSummaryPath, `${formatMarkdown(report)}\n`);
+        }
+
+        if (webhookUrl) {
+          const payload = createWebhookPayload(report, { trigger: "ci", baselinePath });
+          const webhookResult = await sendWebhook(webhookUrl, payload);
+          if (!webhookResult.success) {
+            process.stderr.write(`Warning: Webhook failed: ${webhookResult.error}\n`);
+          }
+        }
+
+        if (unchanged) {
+          return;
+        }
+
+        // Determine exit code using the unfiltered diff
+        const fullReport = diffSnapshots(baseline, current);
+        const failThreshold = SEVERITY_ORDER[failOn];
+        const hasFailure = fullReport.changes.some(
+          (c) => SEVERITY_ORDER[c.severity] >= failThreshold,
+        );
+        if (hasFailure) {
+          throw new CliExitError(1);
+        }
+      }),
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/commands/ci.ts
+++ b/packages/cli/src/commands/ci.ts
@@ -2,9 +2,7 @@ import { appendFileSync } from "node:fs";
 import {
   createWebhookPayload,
   diffSnapshots,
-  formatJson,
   formatMarkdown,
-  formatTerminal,
   SEVERITY_ORDER,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
@@ -21,13 +19,13 @@ import {
   getRootOpts,
   handleErrors,
   parseSeverity,
+  printDeprecationNotice,
   readSnapshotFile,
-  resolveFormat,
-  stripAnsi,
   writeOutput,
 } from "../utils.js";
 import { sendWebhook } from "../webhook.js";
 import { captureSnapshot } from "./capture.js";
+import { formatReport, resolveCheckFormat } from "./check.js";
 
 /**
  * Creates the `ci` subcommand for the mcpdiff CLI.
@@ -55,6 +53,9 @@ export function createCiCommand(): Command {
       handleErrors(async (options: Record<string, unknown>) => {
         const rootOpts = getRootOpts(cmd);
         const quiet = rootOpts["quiet"] === true;
+        if (!quiet) {
+          printDeprecationNotice("mcpdiff ci", "mcpdiff check");
+        }
         const noColor = rootOpts["color"] === false;
         const outputPath = rootOpts["output"] as string | undefined;
         const explicitFormat = rootOpts["format"] as string | undefined;
@@ -93,33 +94,9 @@ export function createCiCommand(): Command {
         // Diff
         const report = diffSnapshots(baseline, current, { minSeverity: severity });
 
-        // Detect CI environment
         const ciEnv = detectCIEnvironment();
-
-        // Resolve format
-        let format: "terminal" | "json" | "markdown";
-        if (explicitFormat) {
-          format = resolveFormat(explicitFormat);
-        } else if (ciEnv.isCI) {
-          format = ciEnv.suggestedFormat as "json" | "markdown";
-        } else {
-          format = resolveFormat(undefined);
-        }
-
-        // Format report
-        let output: string;
-        if (format === "json") {
-          output = formatJson(report);
-        } else if (format === "markdown") {
-          output = formatMarkdown(report);
-        } else {
-          output = formatTerminal(report);
-        }
-
-        if (noColor && format === "terminal") {
-          output = stripAnsi(output);
-        }
-
+        const format = resolveCheckFormat(explicitFormat);
+        const output = formatReport(report, format, noColor);
         writeOutput(`${output}\n`, outputPath);
 
         // GitHub Actions step summary

--- a/packages/cli/src/commands/ci.ts
+++ b/packages/cli/src/commands/ci.ts
@@ -1,16 +1,14 @@
-import { appendFileSync, readFileSync } from "node:fs";
-import type { MCPContractSnapshot, Severity } from "@mcp-contracts/core";
+import { appendFileSync } from "node:fs";
 import {
   createWebhookPayload,
   diffSnapshots,
   formatJson,
   formatMarkdown,
   formatTerminal,
-  parseSignatureFile,
   SEVERITY_ORDER,
-  verifySignature,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
+import { verifyBaselineSignature } from "../baseline-signature.js";
 import { detectCIEnvironment } from "../ci-env.js";
 import {
   loadProjectConfig,
@@ -22,6 +20,7 @@ import {
   CliExitError,
   getRootOpts,
   handleErrors,
+  parseSeverity,
   readSnapshotFile,
   resolveFormat,
   stripAnsi,
@@ -29,23 +28,6 @@ import {
 } from "../utils.js";
 import { sendWebhook } from "../webhook.js";
 import { captureSnapshot } from "./capture.js";
-import { deriveSignaturePath } from "./sign.js";
-
-const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
-
-/**
- * Validates a severity level string.
- *
- * @param value - The string to validate.
- * @param label - Label for the option (used in error messages).
- * @returns The validated Severity value.
- */
-function parseSeverity(value: string, label: string): Severity {
-  if (!VALID_SEVERITIES.has(value)) {
-    throw new Error(`Invalid ${label} value "${value}". Must be one of: safe, warning, breaking`);
-  }
-  return value as Severity;
-}
 
 /**
  * Creates the `ci` subcommand for the mcpdiff CLI.
@@ -173,80 +155,4 @@ export function createCiCommand(): Command {
     );
 
   return cmd;
-}
-
-/**
- * Verifies the baseline snapshot's signature before diffing.
- *
- * @param baseline - The parsed baseline snapshot.
- * @param baselinePath - File path to the baseline (used to derive sig path).
- * @param signatureKeyOption - The --signature-key option value, if provided.
- * @param quiet - Whether to suppress non-essential output.
- */
-function verifyBaselineSignature(
-  baseline: MCPContractSnapshot,
-  baselinePath: string,
-  signatureKeyOption: string | undefined,
-  quiet: boolean,
-): void {
-  const keyPem = resolveSignatureKey(signatureKeyOption);
-  const sigPath = deriveSignaturePath(baselinePath);
-
-  let sigJson: string;
-  try {
-    sigJson = readFileSync(sigPath, "utf-8");
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to read baseline signature file "${sigPath}": ${message}`);
-  }
-
-  const sig = parseSignatureFile(sigJson);
-  const result = verifySignature(baseline, sig, keyPem);
-
-  if (!result.valid) {
-    process.stderr.write(`Baseline signature verification failed: ${result.error}\n`);
-    throw new CliExitError(2);
-  }
-
-  if (!quiet) {
-    process.stderr.write("Baseline signature verified\n");
-  }
-}
-
-/**
- * Resolves the public key PEM for signature verification.
- *
- * Checks the `--signature-key` option first, then the `MCP_SIGNATURE_KEY`
- * environment variable. The env var can contain PEM content directly
- * (starts with "-----BEGIN") or a file path.
- *
- * @param optionValue - The --signature-key option value, if provided.
- * @returns The PEM string for the public key.
- */
-function resolveSignatureKey(optionValue: string | undefined): string {
-  if (optionValue) {
-    try {
-      return readFileSync(optionValue, "utf-8");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to read signature key file "${optionValue}": ${message}`);
-    }
-  }
-
-  const envValue = process.env["MCP_SIGNATURE_KEY"];
-  if (envValue) {
-    if (envValue.startsWith("-----BEGIN")) {
-      return envValue;
-    }
-    try {
-      return readFileSync(envValue, "utf-8");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to read key from MCP_SIGNATURE_KEY path "${envValue}": ${message}`);
-    }
-  }
-
-  throw new Error(
-    "--verify-signature requires --signature-key <path> or MCP_SIGNATURE_KEY environment variable",
-  );
 }

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -18,6 +18,7 @@ import { addTransportOptions } from "../transport.js";
 import {
   CliExitError,
   handleErrors,
+  parseSeverity,
   readSnapshotFile,
   resolveFormat,
   stripAnsi,
@@ -26,22 +27,6 @@ import {
 import { sendWebhook } from "../webhook.js";
 import { captureSnapshot } from "./capture.js";
 import { executeCompositionDiff } from "./diff-composition.js";
-
-const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
-
-/**
- * Validates that a string is a valid Severity level.
- *
- * @param value - The string to validate.
- * @param label - Label for the option (used in error messages).
- * @returns The validated Severity value.
- */
-function parseSeverity(value: string, label: string): Severity {
-  if (!VALID_SEVERITIES.has(value)) {
-    throw new Error(`Invalid ${label} value "${value}". Must be one of: safe, warning, breaking`);
-  }
-  return value as Severity;
-}
 
 /**
  * Resolves the "after" snapshot, either from file or by capturing from a live server.

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -19,6 +19,7 @@ import {
   CliExitError,
   handleErrors,
   parseSeverity,
+  printDeprecationNotice,
   readSnapshotFile,
   resolveFormat,
   stripAnsi,
@@ -128,6 +129,44 @@ async function runFileDiff(params: FileDiffOptions): Promise<void> {
 }
 
 /**
+ * Validates composition-diff arguments and delegates to executeCompositionDiff.
+ *
+ * @param baselineDir - The --baseline directory option value.
+ * @param beforePath - The first positional argument, which must be absent.
+ * @param options - The parsed command options.
+ * @param parentOpts - The root program's parsed options.
+ * @param severity - Minimum severity to display.
+ * @param failOn - Exit code 1 threshold.
+ */
+async function runCompositionDiff(
+  baselineDir: string,
+  beforePath: string | undefined,
+  options: Record<string, unknown>,
+  parentOpts: Record<string, unknown>,
+  severity: Severity,
+  failOn: Severity,
+): Promise<void> {
+  const configPath = options["config"] as string | undefined;
+  if (!configPath) {
+    throw new Error("--baseline requires --config");
+  }
+  if (beforePath) {
+    throw new Error("--baseline cannot be combined with snapshot file arguments");
+  }
+
+  await executeCompositionDiff({
+    configPath,
+    baselineDir,
+    minSeverity: severity,
+    failOn,
+    quiet: parentOpts["quiet"] === true,
+    format: resolveFormat(parentOpts["format"] as string | undefined),
+    noColor: parentOpts["color"] === false,
+    outputPath: parentOpts["output"] as string | undefined,
+  });
+}
+
+/**
  * Creates the `diff` subcommand for the mcpdiff CLI.
  *
  * Supports two modes:
@@ -162,30 +201,15 @@ export function createDiffCommand(): Command {
         const severity = parseSeverity(options["severity"] as string, "--severity");
         const failOn = parseSeverity(options["failOn"] as string, "--fail-on");
         const live = options["live"] === true;
-
         const parentOpts = cmd.parent?.opts() ?? {};
         const quiet = parentOpts["quiet"] === true;
+        if (live && !quiet) {
+          printDeprecationNotice("mcpdiff diff --live", "mcpdiff check");
+        }
 
         const baselineDir = options["baseline"] as string | undefined;
         if (baselineDir) {
-          const configPath = options["config"] as string | undefined;
-          if (!configPath) {
-            throw new Error("--baseline requires --config");
-          }
-          if (beforePath) {
-            throw new Error("--baseline cannot be combined with snapshot file arguments");
-          }
-
-          await executeCompositionDiff({
-            configPath,
-            baselineDir,
-            minSeverity: severity,
-            failOn,
-            quiet,
-            format: resolveFormat(parentOpts["format"] as string | undefined),
-            noColor: parentOpts["color"] === false,
-            outputPath: parentOpts["output"] as string | undefined,
-          });
+          await runCompositionDiff(baselineDir, beforePath, options, parentOpts, severity, failOn);
           return;
         }
 

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,0 +1,183 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createSnapshot } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { createUpdateCommand } from "./update.js";
+
+/** Creates a snapshot matching the mock captureSnapshot output. */
+function makeMockSnapshot() {
+  return createSnapshot({
+    server: {
+      name: "test-server",
+      version: "1.0.0",
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+    },
+    tools: [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    capture: { transport: "stdio", source: "node", tool: "mcpdiff/0.1.0" },
+  });
+}
+
+vi.mock("./capture.js", () => ({
+  captureSnapshot: vi.fn().mockImplementation(async () => ({
+    snapshot: makeMockSnapshot(),
+    serverName: "test-server",
+    serverVersion: "1.0.0",
+  })),
+}));
+
+const TMP_DIR = resolve(import.meta.dirname, "__tmp_update_test");
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file path")
+    .option("--quiet", "Suppress non-essential output")
+    .option("--verbose", "Show detailed information")
+    .option("--project <path>", "Path to mcpcontracts.json");
+  program.addCommand(createUpdateCommand());
+  return program;
+}
+
+describe("update command", () => {
+  let stderrData: string;
+  let exitCode: number | undefined;
+  let stderrSpy: MockInstance;
+  let exitSpy: MockInstance;
+  let stdoutSpy: MockInstance;
+
+  beforeEach(() => {
+    stderrData = "";
+    exitCode = undefined;
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+    mkdirSync(TMP_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    if (existsSync(TMP_DIR)) {
+      rmSync(TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a valid snapshot to the --baseline path", async () => {
+    const outPath = resolve(TMP_DIR, "baseline.mcpc.json");
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "update",
+      "--baseline",
+      outPath,
+      "--command",
+      "node",
+    ]);
+    const snapshot = JSON.parse(readFileSync(outPath, "utf-8"));
+    expect(snapshot.snapshotVersion).toBe("1.0.0");
+    expect(snapshot.server.name).toBe("test-server");
+    expect(snapshot.contentHash).toMatch(/^sha256:/);
+    expect(Object.keys(snapshot.tools)).toContain("test_tool");
+    expect(stderrData).toContain(`Baseline written to ${outPath}`);
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("accepts the global -o option for the output path", async () => {
+    const outPath = resolve(TMP_DIR, "via-output.mcpc.json");
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "-o", outPath, "update", "--command", "node"]);
+    expect(existsSync(outPath)).toBe(true);
+  });
+
+  it("prefers --baseline over the global -o option", async () => {
+    const baselinePath = resolve(TMP_DIR, "from-baseline.mcpc.json");
+    const outputPath = resolve(TMP_DIR, "from-output.mcpc.json");
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "-o",
+      outputPath,
+      "update",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+    ]);
+    expect(existsSync(baselinePath)).toBe(true);
+    expect(existsSync(outputPath)).toBe(false);
+  });
+
+  it("creates missing directories", async () => {
+    const nestedPath = resolve(TMP_DIR, "nested/dir/baseline.mcpc.json");
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "update",
+      "--baseline",
+      nestedPath,
+      "--command",
+      "node",
+    ]);
+    expect(existsSync(nestedPath)).toBe(true);
+  });
+
+  it("resolves the baseline path from the project config", async () => {
+    const projectPath = resolve(TMP_DIR, "mcpcontracts.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ baseline: "contracts/config-baseline.mcpc.json" }),
+      "utf-8",
+    );
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--project",
+      projectPath,
+      "update",
+      "--command",
+      "node",
+    ]);
+    expect(existsSync(resolve(TMP_DIR, "contracts/config-baseline.mcpc.json"))).toBe(true);
+  });
+
+  it("errors with exit 2 when no transport is available", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "update",
+        "--baseline",
+        resolve(TMP_DIR, "x.mcpc.json"),
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Specify one of");
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,55 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { Command } from "commander";
+import {
+  DEFAULT_BASELINE_PATH,
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import { getRootOpts, handleErrors, writeOutput } from "../utils.js";
+import { captureSnapshot } from "./capture.js";
+
+/**
+ * Creates the `update` subcommand for the mcpdiff CLI.
+ *
+ * Captures a snapshot from the live server and writes it as the baseline.
+ * The path comes from --baseline, then the global --output option, then the
+ * project config's "baseline", then contracts/baseline.mcpc.json. For ad-hoc
+ * snapshots that are not baselines, use `snapshot -o <file>`.
+ *
+ * @returns A Commander Command instance for the update subcommand.
+ */
+export function createUpdateCommand(): Command {
+  const cmd = new Command("update").description("Capture the live server and write the baseline");
+
+  addTransportOptions(cmd);
+
+  cmd
+    .option("--baseline <path>", `Path to write the baseline (default: "${DEFAULT_BASELINE_PATH}")`)
+    .action(
+      handleErrors(async (options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const quiet = rootOpts["quiet"] === true;
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+
+        const flagPath =
+          (options["baseline"] as string | undefined) ?? (rootOpts["output"] as string | undefined);
+        const outputPath = resolveBaselinePath(flagPath, project) ?? DEFAULT_BASELINE_PATH;
+
+        const transport = resolveTransportOrProject(options, project);
+
+        const { snapshot } = await captureSnapshot({ transport, quiet });
+
+        mkdirSync(dirname(outputPath), { recursive: true });
+        writeOutput(`${JSON.stringify(snapshot, null, 2)}\n`, outputPath);
+
+        if (!quiet) {
+          process.stderr.write(`Baseline written to ${outputPath}\n`);
+        }
+      }),
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -9,7 +9,7 @@ import {
   resolveTransportOrProject,
 } from "../project-config.js";
 import { addTransportOptions } from "../transport.js";
-import { getRootOpts, handleErrors, parseSeverity } from "../utils.js";
+import { getRootOpts, handleErrors, parseSeverity, printDeprecationNotice } from "../utils.js";
 import { runWatchLoop } from "../watch-loop.js";
 
 /** Watch options resolved from CLI flags and the project config. */
@@ -85,6 +85,9 @@ export function createWatchCommand(): Command {
       handleErrors(async (options: Record<string, unknown>) => {
         const rootOpts = getRootOpts(cmd);
         const quiet = rootOpts["quiet"] === true;
+        if (!quiet) {
+          printDeprecationNotice("mcpdiff watch", "mcpdiff check --watch");
+        }
         const project = loadProjectConfig(rootOpts["project"] as string | undefined);
 
         const { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear } =

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -2,6 +2,7 @@ import type { Severity } from "@mcp-contracts/core";
 import { Command } from "commander";
 import type { LoadedProjectConfig } from "../project-config.js";
 import {
+  DEFAULT_BASELINE_PATH,
   loadProjectConfig,
   resolveBaselinePath,
   resolveProjectPath,
@@ -47,10 +48,9 @@ export function resolveWatchOptions(
     resolveProjectPath(project, p),
   );
   const watchPaths = (options["watchPaths"] as string[] | undefined) ?? projectWatchPaths ?? ["."];
-  const baselinePath = resolveBaselinePath(options["baseline"] as string | undefined, project);
-  if (!baselinePath) {
-    throw new Error('--baseline is required (or set "baseline" in mcpcontracts.json)');
-  }
+  const baselinePath =
+    resolveBaselinePath(options["baseline"] as string | undefined, project) ??
+    DEFAULT_BASELINE_PATH;
   const webhookUrl = options["webhook"] as string | undefined;
   const shouldClear =
     options["clear"] === true || (options["clear"] === undefined && process.stdout.isTTY);
@@ -74,7 +74,7 @@ export function createWatchCommand(): Command {
   addTransportOptions(cmd);
 
   cmd
-    .option("--baseline <path>", "Path to baseline snapshot")
+    .option("--baseline <path>", `Path to baseline snapshot (default: "${DEFAULT_BASELINE_PATH}")`)
     .option("--watch-paths <paths...>", 'Paths to watch for changes (default: ".")')
     .option("--debounce <ms>", "Debounce interval in milliseconds (default: 500)")
     .option("--severity <level>", "Minimum severity to display", "safe")

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -1,20 +1,4 @@
-import { watch } from "node:fs/promises";
-import { resolve } from "node:path";
-import type {
-  DiffReport,
-  MCPContractSnapshot,
-  Severity,
-  WatchConfig,
-  WatchDiffEvent,
-} from "@mcp-contracts/core";
-import {
-  createWatchConfig,
-  createWebhookPayload,
-  DEFAULT_WATCH_IGNORE_PATTERNS,
-  diffSnapshots,
-  formatTerminal,
-  SEVERITY_ORDER,
-} from "@mcp-contracts/core";
+import type { Severity } from "@mcp-contracts/core";
 import { Command } from "commander";
 import type { LoadedProjectConfig } from "../project-config.js";
 import {
@@ -24,99 +8,8 @@ import {
   resolveTransportOrProject,
 } from "../project-config.js";
 import { addTransportOptions } from "../transport.js";
-import { getRootOpts, handleErrors, readSnapshotFile } from "../utils.js";
-import {
-  clearScreen,
-  formatWatchCycle,
-  formatWatchError,
-  formatWatchHeader,
-} from "../watch-output.js";
-import { sendWebhook } from "../webhook.js";
-import { captureSnapshot } from "./capture.js";
-
-const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
-
-/**
- * Validates that a string is a valid Severity level.
- *
- * @param value - The string to validate.
- * @param label - Label for the option (used in error messages).
- * @returns The validated Severity value.
- */
-function parseSeverity(value: string, label: string): Severity {
-  if (!VALID_SEVERITIES.has(value)) {
-    throw new Error(`Invalid ${label} value "${value}". Must be one of: safe, warning, breaking`);
-  }
-  return value as Severity;
-}
-
-/**
- * Checks if a file path matches any of the ignore patterns.
- *
- * @param filePath - The file path to check.
- * @param patterns - Glob-like patterns to match against.
- * @returns True if the path should be ignored.
- */
-function shouldIgnore(filePath: string, patterns: string[]): boolean {
-  for (const pattern of patterns) {
-    // Simple glob matching: convert ** and * to regex
-    const escaped = pattern
-      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-      .replace(/\*\*/g, "{{GLOBSTAR}}")
-      .replace(/\*/g, "[^/]*")
-      .replace(/\{\{GLOBSTAR\}\}/g, ".*");
-    const regex = new RegExp(escaped);
-    if (regex.test(filePath)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Sends a webhook notification for a diff report if configured.
- *
- * @param webhookUrl - The URL to POST to, or undefined to skip.
- * @param report - The diff report to send.
- * @param baselinePath - Path to the baseline snapshot file.
- */
-async function maybeSendWebhook(
-  webhookUrl: string | undefined,
-  report: DiffReport,
-  baselinePath: string,
-): Promise<void> {
-  if (!webhookUrl) return;
-  const payload = createWebhookPayload(report, {
-    trigger: "watch",
-    baselinePath,
-  });
-  const result = await sendWebhook(webhookUrl, payload);
-  if (!result.success) {
-    process.stderr.write(`Warning: Webhook failed: ${result.error}\n`);
-  }
-}
-
-/**
- * Checks if a diff report contains changes above the fail threshold and warns.
- *
- * @param baseline - The baseline snapshot.
- * @param current - The current snapshot.
- * @param config - Watch configuration.
- * @param quiet - Whether to suppress output.
- */
-function checkFailThreshold(
-  baseline: MCPContractSnapshot,
-  current: MCPContractSnapshot,
-  config: WatchConfig,
-  quiet: boolean,
-): void {
-  const fullReport = diffSnapshots(baseline, current);
-  const failThreshold = SEVERITY_ORDER[config.failOn];
-  const hasFailure = fullReport.changes.some((c) => SEVERITY_ORDER[c.severity] >= failThreshold);
-  if (hasFailure && !quiet) {
-    process.stderr.write("Breaking changes detected!\n");
-  }
-}
+import { getRootOpts, handleErrors, parseSeverity } from "../utils.js";
+import { runWatchLoop } from "../watch-loop.js";
 
 /** Watch options resolved from CLI flags and the project config. */
 interface ResolvedWatchOptions {
@@ -137,7 +30,7 @@ interface ResolvedWatchOptions {
  * @param project - The loaded project config, if any.
  * @returns The fully resolved watch options.
  */
-function resolveWatchOptions(
+export function resolveWatchOptions(
   options: Record<string, unknown>,
   project: LoadedProjectConfig | null,
 ): ResolvedWatchOptions {
@@ -197,117 +90,19 @@ export function createWatchCommand(): Command {
         const { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear } =
           resolveWatchOptions(options, project);
 
-        const config = createWatchConfig({
-          debounceMs,
-          watchPaths,
-          minSeverity: severity,
-          failOn,
-        });
-
         const transport = resolveTransportOrProject(options, project);
 
-        // Print header
-        process.stderr.write(formatWatchHeader(baselinePath, watchPaths, debounceMs));
-
-        // Set up abort controller for graceful shutdown
-        const ac = new AbortController();
-
-        const shutdown = () => {
-          process.stderr.write("\nShutting down watch mode...\n");
-          ac.abort();
-        };
-        process.on("SIGINT", shutdown);
-        process.on("SIGTERM", shutdown);
-
-        let cycle = 0;
-        let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-        let pendingPaths: string[] = [];
-
-        /**
-         * Runs a single diff cycle.
-         *
-         * @param triggerPaths - File paths that triggered this cycle.
-         */
-        async function runCycle(triggerPaths: string[]): Promise<void> {
-          cycle++;
-          const start = Date.now();
-
-          let event: WatchDiffEvent;
-
-          try {
-            const baseline = readSnapshotFile(baselinePath);
-            const { snapshot: current } = await captureSnapshot({ transport, quiet: true });
-            const report = diffSnapshots(baseline, current, { minSeverity: config.minSeverity });
-
-            event = {
-              cycle,
-              timestamp: new Date().toISOString(),
-              report,
-              triggerPaths,
-              durationMs: Date.now() - start,
-            };
-
-            if (shouldClear) {
-              process.stdout.write(clearScreen());
-            }
-
-            process.stdout.write(formatWatchCycle(event, formatTerminal));
-
-            await maybeSendWebhook(webhookUrl, report, baselinePath);
-            checkFailThreshold(baseline, current, config, quiet);
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            event = {
-              cycle,
-              timestamp: new Date().toISOString(),
-              triggerPaths,
-              durationMs: Date.now() - start,
-              error: message,
-            };
-            process.stderr.write(formatWatchError(event));
-          }
-        }
-
-        // Start watching
-        const resolvedPaths = watchPaths.map((p) => resolve(p));
-        const watchers = resolvedPaths.map((p) => watch(p, { recursive: true, signal: ac.signal }));
-
-        try {
-          // Use Promise.race of all watchers to handle events
-          const watcherPromises = watchers.map(async (watcher) => {
-            for await (const event of watcher) {
-              if (ac.signal.aborted) break;
-              const filename = event.filename ?? "";
-              if (shouldIgnore(filename, [...DEFAULT_WATCH_IGNORE_PATTERNS])) {
-                continue;
-              }
-              pendingPaths.push(filename);
-
-              if (debounceTimer) {
-                clearTimeout(debounceTimer);
-              }
-              debounceTimer = setTimeout(() => {
-                const paths = [...pendingPaths];
-                pendingPaths = [];
-                runCycle(paths);
-              }, config.debounceMs);
-            }
-          });
-
-          await Promise.all(watcherPromises);
-        } catch (err) {
-          if (err instanceof Error && err.name === "AbortError") {
-            // Expected on shutdown
-          } else {
-            throw err;
-          }
-        } finally {
-          process.removeListener("SIGINT", shutdown);
-          process.removeListener("SIGTERM", shutdown);
-          if (debounceTimer) {
-            clearTimeout(debounceTimer);
-          }
-        }
+        await runWatchLoop({
+          transport,
+          baselinePath,
+          watchPaths,
+          debounceMs,
+          minSeverity: severity,
+          failOn,
+          webhookUrl,
+          shouldClear,
+          quiet,
+        });
       }),
     );
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,9 +39,9 @@ program
 
 program.addCommand(createCheckCommand());
 program.addCommand(createUpdateCommand());
-program.addCommand(createBaselineCommand());
+program.addCommand(createBaselineCommand(), { hidden: true });
 program.addCommand(createCheckConflictsCommand());
-program.addCommand(createCiCommand());
+program.addCommand(createCiCommand(), { hidden: true });
 program.addCommand(createDiffCommand());
 program.addCommand(createGraphCommand());
 program.addCommand(createInspectCommand());
@@ -49,6 +49,6 @@ program.addCommand(createSignCommand());
 program.addCommand(createSnapshotCommand());
 program.addCommand(createVerifyCommand());
 program.addCommand(createVerifyHashCommand());
-program.addCommand(createWatchCommand());
+program.addCommand(createWatchCommand(), { hidden: true });
 
 program.parse();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@
 
 import { Command } from "commander";
 import { createBaselineCommand } from "./commands/baseline.js";
+import { createCheckCommand } from "./commands/check.js";
 import { createCheckConflictsCommand } from "./commands/check-conflicts.js";
 import { createCiCommand } from "./commands/ci.js";
 import { createDiffCommand } from "./commands/diff.js";
@@ -15,6 +16,7 @@ import { createGraphCommand } from "./commands/graph.js";
 import { createInspectCommand } from "./commands/inspect.js";
 import { createSignCommand } from "./commands/sign.js";
 import { createSnapshotCommand } from "./commands/snapshot.js";
+import { createUpdateCommand } from "./commands/update.js";
 import { createVerifyCommand } from "./commands/verify.js";
 import { createVerifyHashCommand } from "./commands/verify-hash.js";
 import { createWatchCommand } from "./commands/watch.js";
@@ -35,6 +37,8 @@ program
     "Path to mcpcontracts.json (default: discovered by walking up from the CWD)",
   );
 
+program.addCommand(createCheckCommand());
+program.addCommand(createUpdateCommand());
 program.addCommand(createBaselineCommand());
 program.addCommand(createCheckConflictsCommand());
 program.addCommand(createCiCommand());

--- a/packages/cli/src/project-config.ts
+++ b/packages/cli/src/project-config.ts
@@ -20,6 +20,9 @@ import type { ResolvedTransport } from "./commands/mcp-client.js";
 import { readMcpConfig } from "./mcp-config.js";
 import { extractTransportOptions, hasTransportFlags, resolveTransport } from "./transport.js";
 
+/** Default baseline path used when neither flags nor config specify one. */
+export const DEFAULT_BASELINE_PATH = "contracts/baseline.mcpc.json";
+
 /** A project config together with where it was found. */
 export interface LoadedProjectConfig {
   /** Absolute path to the config file. */

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,6 +1,22 @@
 import { readFileSync, writeFileSync } from "node:fs";
-import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import type { MCPContractSnapshot, Severity } from "@mcp-contracts/core";
 import type { Command } from "commander";
+
+const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
+
+/**
+ * Validates that a string is a valid Severity level.
+ *
+ * @param value - The string to validate.
+ * @param label - Label for the option (used in error messages).
+ * @returns The validated Severity value.
+ */
+export function parseSeverity(value: string, label: string): Severity {
+  if (!VALID_SEVERITIES.has(value)) {
+    throw new Error(`Invalid ${label} value "${value}". Must be one of: safe, warning, breaking`);
+  }
+  return value as Severity;
+}
 
 /**
  * Resolves the root program options from a possibly nested subcommand.

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -19,6 +19,18 @@ export function parseSeverity(value: string, label: string): Severity {
 }
 
 /**
+ * Prints a one-line deprecation notice to stderr.
+ *
+ * @param oldSpelling - The deprecated command spelling (e.g. "mcpdiff ci").
+ * @param newSpelling - The replacement to point users at (e.g. "mcpdiff check").
+ */
+export function printDeprecationNotice(oldSpelling: string, newSpelling: string): void {
+  process.stderr.write(
+    `Warning: '${oldSpelling}' is deprecated and will be removed in a future release; use '${newSpelling}' instead\n`,
+  );
+}
+
+/**
  * Resolves the root program options from a possibly nested subcommand.
  *
  * @param cmd - The current Command instance.

--- a/packages/cli/src/watch-loop.ts
+++ b/packages/cli/src/watch-loop.ts
@@ -1,0 +1,244 @@
+/**
+ * The watch-mode loop: re-capture and re-diff a live server on file changes.
+ *
+ * Shared by `check --watch` and the deprecated `watch` command.
+ */
+
+import { watch } from "node:fs/promises";
+import { resolve } from "node:path";
+import type {
+  DiffReport,
+  MCPContractSnapshot,
+  Severity,
+  WatchConfig,
+  WatchDiffEvent,
+} from "@mcp-contracts/core";
+import {
+  createWatchConfig,
+  createWebhookPayload,
+  DEFAULT_WATCH_IGNORE_PATTERNS,
+  diffSnapshots,
+  formatTerminal,
+  SEVERITY_ORDER,
+} from "@mcp-contracts/core";
+import { captureSnapshot } from "./commands/capture.js";
+import type { ResolvedTransport } from "./commands/mcp-client.js";
+import { readSnapshotFile } from "./utils.js";
+import {
+  clearScreen,
+  formatWatchCycle,
+  formatWatchError,
+  formatWatchHeader,
+} from "./watch-output.js";
+import { sendWebhook } from "./webhook.js";
+
+/** Parameters for running the watch loop. */
+export interface WatchLoopParams {
+  /** How to reach the MCP server. */
+  transport: ResolvedTransport;
+  /** Path to the baseline snapshot file. */
+  baselinePath: string;
+  /** Paths to watch for changes. */
+  watchPaths: string[];
+  /** Debounce interval in milliseconds. */
+  debounceMs: number;
+  /** Minimum severity to display. */
+  minSeverity: Severity;
+  /** Severity threshold for the breaking-changes warning. */
+  failOn: Severity;
+  /** Webhook URL to POST diffs to on each cycle, if any. */
+  webhookUrl: string | undefined;
+  /** Clear the screen between diff cycles. */
+  shouldClear: boolean;
+  /** Suppress non-essential output. */
+  quiet: boolean;
+}
+
+/**
+ * Checks if a file path matches any of the ignore patterns.
+ *
+ * @param filePath - The file path to check.
+ * @param patterns - Glob-like patterns to match against.
+ * @returns True if the path should be ignored.
+ */
+function shouldIgnore(filePath: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    // Simple glob matching: convert ** and * to regex
+    const escaped = pattern
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/\*\*/g, "{{GLOBSTAR}}")
+      .replace(/\*/g, "[^/]*")
+      .replace(/\{\{GLOBSTAR\}\}/g, ".*");
+    const regex = new RegExp(escaped);
+    if (regex.test(filePath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Sends a webhook notification for a diff report if configured.
+ *
+ * @param webhookUrl - The URL to POST to, or undefined to skip.
+ * @param report - The diff report to send.
+ * @param baselinePath - Path to the baseline snapshot file.
+ */
+async function maybeSendWebhook(
+  webhookUrl: string | undefined,
+  report: DiffReport,
+  baselinePath: string,
+): Promise<void> {
+  if (!webhookUrl) return;
+  const payload = createWebhookPayload(report, {
+    trigger: "watch",
+    baselinePath,
+  });
+  const result = await sendWebhook(webhookUrl, payload);
+  if (!result.success) {
+    process.stderr.write(`Warning: Webhook failed: ${result.error}\n`);
+  }
+}
+
+/**
+ * Checks if a diff report contains changes above the fail threshold and warns.
+ *
+ * @param baseline - The baseline snapshot.
+ * @param current - The current snapshot.
+ * @param config - Watch configuration.
+ * @param quiet - Whether to suppress output.
+ */
+function checkFailThreshold(
+  baseline: MCPContractSnapshot,
+  current: MCPContractSnapshot,
+  config: WatchConfig,
+  quiet: boolean,
+): void {
+  const fullReport = diffSnapshots(baseline, current);
+  const failThreshold = SEVERITY_ORDER[config.failOn];
+  const hasFailure = fullReport.changes.some((c) => SEVERITY_ORDER[c.severity] >= failThreshold);
+  if (hasFailure && !quiet) {
+    process.stderr.write("Breaking changes detected!\n");
+  }
+}
+
+/**
+ * Watches for file changes and re-diffs the live server against the baseline
+ * on each change, until interrupted (SIGINT/SIGTERM).
+ *
+ * @param params - The fully resolved watch parameters.
+ */
+export async function runWatchLoop(params: WatchLoopParams): Promise<void> {
+  const { transport, baselinePath, watchPaths, debounceMs, webhookUrl, shouldClear, quiet } =
+    params;
+
+  const config = createWatchConfig({
+    debounceMs,
+    watchPaths,
+    minSeverity: params.minSeverity,
+    failOn: params.failOn,
+  });
+
+  // Print header
+  process.stderr.write(formatWatchHeader(baselinePath, watchPaths, debounceMs));
+
+  // Set up abort controller for graceful shutdown
+  const ac = new AbortController();
+
+  const shutdown = () => {
+    process.stderr.write("\nShutting down watch mode...\n");
+    ac.abort();
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  let cycle = 0;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingPaths: string[] = [];
+
+  /**
+   * Runs a single diff cycle.
+   *
+   * @param triggerPaths - File paths that triggered this cycle.
+   */
+  async function runCycle(triggerPaths: string[]): Promise<void> {
+    cycle++;
+    const start = Date.now();
+
+    let event: WatchDiffEvent;
+
+    try {
+      const baseline = readSnapshotFile(baselinePath);
+      const { snapshot: current } = await captureSnapshot({ transport, quiet: true });
+      const report = diffSnapshots(baseline, current, { minSeverity: config.minSeverity });
+
+      event = {
+        cycle,
+        timestamp: new Date().toISOString(),
+        report,
+        triggerPaths,
+        durationMs: Date.now() - start,
+      };
+
+      if (shouldClear) {
+        process.stdout.write(clearScreen());
+      }
+
+      process.stdout.write(formatWatchCycle(event, formatTerminal));
+
+      await maybeSendWebhook(webhookUrl, report, baselinePath);
+      checkFailThreshold(baseline, current, config, quiet);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      event = {
+        cycle,
+        timestamp: new Date().toISOString(),
+        triggerPaths,
+        durationMs: Date.now() - start,
+        error: message,
+      };
+      process.stderr.write(formatWatchError(event));
+    }
+  }
+
+  // Start watching
+  const resolvedPaths = watchPaths.map((p) => resolve(p));
+  const watchers = resolvedPaths.map((p) => watch(p, { recursive: true, signal: ac.signal }));
+
+  try {
+    // Use Promise.race of all watchers to handle events
+    const watcherPromises = watchers.map(async (watcher) => {
+      for await (const event of watcher) {
+        if (ac.signal.aborted) break;
+        const filename = event.filename ?? "";
+        if (shouldIgnore(filename, [...DEFAULT_WATCH_IGNORE_PATTERNS])) {
+          continue;
+        }
+        pendingPaths.push(filename);
+
+        if (debounceTimer) {
+          clearTimeout(debounceTimer);
+        }
+        debounceTimer = setTimeout(() => {
+          const paths = [...pendingPaths];
+          pendingPaths = [];
+          runCycle(paths);
+        }, config.debounceMs);
+      }
+    });
+
+    await Promise.all(watcherPromises);
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      // Expected on shutdown
+    } else {
+      throw err;
+    }
+  } finally {
+    process.removeListener("SIGINT", shutdown);
+    process.removeListener("SIGTERM", shutdown);
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+  }
+}

--- a/packages/core/src/diff.test.ts
+++ b/packages/core/src/diff.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { diffSnapshots } from "./diff.js";
+import { createEmptyDiffReport, diffSnapshots } from "./diff.js";
 import type { MCPContractSnapshot } from "./types.js";
 
 function loadFixture(name: string): MCPContractSnapshot {
@@ -271,5 +271,16 @@ describe("diffSnapshots — prompt changes", () => {
     );
     expect(descChange).toHaveLength(1);
     expect(descChange[0]?.severity).toBe("warning");
+  });
+});
+
+describe("createEmptyDiffReport", () => {
+  it("builds a no-changes report without running the diff engine", () => {
+    const v1 = loadFixture("server-v1.mcpc.json");
+    const report = createEmptyDiffReport(v1, v1);
+    expect(report.changes).toHaveLength(0);
+    expect(report.summary).toEqual({ breaking: 0, warning: 0, safe: 0, total: 0 });
+    expect(report.meta.before.serverName).toBe(v1.server.name);
+    expect(report.meta.after.contentHash).toBe(v1.contentHash);
   });
 });

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -337,6 +337,27 @@ function diffPrompts(before: MCPContractSnapshot, after: MCPContractSnapshot): S
 }
 
 /**
+ * Builds a no-changes diff report without running the diff engine.
+ *
+ * Used as a fast path when the caller already knows the snapshots are
+ * identical (e.g. matching content hashes on honestly generated snapshots).
+ *
+ * @param before - The baseline snapshot.
+ * @param after - The updated snapshot.
+ * @returns A DiffReport with empty changes and zeroed summary counts.
+ */
+export function createEmptyDiffReport(
+  before: MCPContractSnapshot,
+  after: MCPContractSnapshot,
+): DiffReport {
+  return {
+    meta: buildMeta(before, after),
+    summary: buildSummary([]),
+    changes: [],
+  };
+}
+
+/**
  * Compares two MCP Contract Snapshots and returns a detailed diff report.
  *
  * @param before - The baseline snapshot.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,7 @@ export type {
   ServerSnapshotEntry,
   ToolCollision,
 } from "./composition-types.js";
-export { diffSnapshots } from "./diff.js";
+export { createEmptyDiffReport, diffSnapshots } from "./diff.js";
 export type {
   ChangeCategory,
   ChangeType,


### PR DESCRIPTION
## Summary

Implements #59: the five overlapping entry points for "capture the live server and compare it to the baseline" collapse into two verbs.

- **`mcpdiff check`** — capture, diff against the baseline, report, exit 0/1/2. Every flag works in every mode: `--fail-on`, `--severity`, `--webhook`, `--verify-signature`/`--signature-key`, transport flags, and `--watch` (with `--watch-paths`, `--debounce`, `--clear`). CI environment auto-detection and `GITHUB_STEP_SUMMARY` moved in from `ci`; the content-hash fast path moved in from `baseline verify` (matching hashes skip the diff engine, via a new `createEmptyDiffReport` core helper). Reads `mcpcontracts.json` — `mcpdiff check` with zero flags is the headline UX.
- **`mcpdiff update`** — captures the live server and writes the baseline (`--baseline` > global `-o` > config > `contracts/baseline.mcpc.json`). `snapshot -o` remains for ad-hoc, non-baseline snapshots.

## Deprecations (kept working)

`ci`, `watch`, `baseline update`, `baseline verify`, and `diff --live` are hidden from `--help` but keep their exact behavior and exit codes, printing a one-line stderr notice pointing at the replacement (suppressed by `--quiet`). Removal is planned for the next minor per the migration plan in #59.

## Notes

- The exit-code contract is unchanged: 0 = clean, 1 = threshold exceeded, 2 = tool error.
- `watch`/`check --watch` now default the baseline to `contracts/baseline.mcpc.json` instead of requiring `--baseline`, consistent with the rest of the consolidated surface.
- Shared logic extracted rather than duplicated: watch loop, baseline signature verification, severity parsing, and report formatting are single-sourced modules now used by both the new and deprecated commands.
- README restructured: `check`/`update` are the documented flow; deprecated commands removed from docs with a short migration note.
- The `github-action` repo switch to `check` is intentionally left for a follow-up, as planned in #59.

## Testing

- 17 new unit tests for `check`/`update` (ported from the `ci`/`baseline` suites) plus integration tests: zero-flag `update` → `check` roundtrip, consolidated flag surface, hidden-from-help assertions, and each deprecated spelling still working with its notice.
- Full matrix green: 557 tests across core/cli/test, typecheck, biome.
- Verified end-to-end against `example-contact-server`: zero-flag `check`/`update`/`check --watch`, subdirectory discovery, breaking-change exit 1, deprecation notices.

Refs #59