### PR TITLE
v0.7.0 — Developer Experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, "milestone/**"]
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Output:
 
 ## Commands
 
-> Migrating from an older version? `ci`, `watch`, `baseline verify`, `baseline update`, and `diff --live` still work but are deprecated — they are replaced by `check` (with `--watch`) and `update`, and will be removed in a future release.
+> Migrating from an older version? `ci`, `watch`, `baseline verify`, `baseline update`, `diff --live`, and `verify-hash` still work but are deprecated — they are replaced by `check` (with `--watch`), `update`, and `verify` (without `--key`), and will be removed in a future release.
 
 ### `mcpdiff snapshot`
 
@@ -185,28 +185,23 @@ The sign command verifies the content hash before signing — it will refuse to 
 
 ### `mcpdiff verify`
 
-Verifies a snapshot's signature using a public key.
+Verifies the integrity/authenticity of a snapshot file.
 
 ```bash
-# Verify (auto-discovers .mcpc.sig file next to the snapshot)
+# Content hash check only — no keys needed
+mcpdiff verify snapshot.mcpc.json
+
+# Full signature verification (auto-discovers the .mcpc.sig next to the snapshot)
 mcpdiff verify contracts/baseline.mcpc.json --key ./public.pem
 
 # Explicit signature path
 mcpdiff verify snapshot.mcpc.json --key ./public.pem --signature custom/path.mcpc.sig
+
+# JSON output reports which checks ran: ["hash"] or ["hash", "binding", "signature"]
+mcpdiff verify snapshot.mcpc.json --format json
 ```
 
-Performs three checks: content hash integrity, hash binding (signature matches this snapshot), and cryptographic verification. Exit code 0 on success, 1 on failure.
-
-### `mcpdiff verify-hash`
-
-Quick integrity check — recomputes the content hash and compares to the stored value. No keys needed.
-
-```bash
-mcpdiff verify-hash snapshot.mcpc.json
-
-# JSON output
-mcpdiff verify-hash snapshot.mcpc.json --format json
-```
+Without `--key`, only the content hash is recomputed and compared (the output says so, so the weaker check is never mistaken for the stronger one). With `--key`, three checks run: content hash integrity, hash binding (signature matches this snapshot), and cryptographic verification. Exit code 0 on success, 1 on failure.
 
 ### `mcpdiff inspect`
 
@@ -270,7 +265,7 @@ mcpdiff check                  # zero flags locally and in CI
 mcpdiff check --watch          # zero flags in dev
 ```
 
-The config is read by every command that connects to a live server: `check`, `update`, and `snapshot`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`, `verify-hash`) ignore it.
+The config is read by every command that connects to a live server: `check`, `update`, and `snapshot`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`) ignore it.
 
 **Precedence:** explicit CLI flags > config file > built-in defaults. Passing any transport flag (`--command`, `--url`, `--config`, …) ignores the config's `server` block entirely — the two sources are never partially merged. `failOn` and the `watch` block apply to `check`.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ mcpdiff test contract.mcpc.json --url http://localhost:3000/mcp --allow-extra-to
 
 # Tune the suite
 mcpdiff test --no-boundary --skip-tools delete_contact --timeout 60000
+mcpdiff test --no-conformance                  # boundary tests only
+mcpdiff test --ignore-descriptions             # tolerate description drift
 ```
 
 **Exit codes:** `0` = all pass, `1` = failures, `2` = error. The standalone `mcp-test` bin still works but points here; the `@mcp-contracts/test` package remains the library for vitest integration.
@@ -134,8 +136,8 @@ tools, plus overlap edges where two servers expose the same tool name.
 mcpdiff graph --config ./mcp.json
 
 # Mermaid or Graphviz output for docs
-mcpdiff --format mermaid graph --config ./mcp.json
-mcpdiff --format dot graph --config ./mcp.json
+mcpdiff graph --config ./mcp.json --format mermaid
+mcpdiff graph --config ./mcp.json --format dot
 ```
 
 ### `mcpdiff init`
@@ -175,7 +177,7 @@ mcpdiff check --fail-on warning
 mcpdiff check --severity breaking
 
 # Re-run on file changes during development
-mcpdiff check --watch --watch-paths src --debounce 1000
+mcpdiff check --watch --watch-paths src --debounce 1000 --clear
 
 # Require a valid signature on the baseline before diffing
 mcpdiff check --verify-signature --signature-key ./public.pem
@@ -249,6 +251,8 @@ Summarizes a snapshot file.
 ```bash
 mcpdiff inspect snapshot.mcpc.json
 mcpdiff inspect snapshot.mcpc.json --tools
+mcpdiff inspect snapshot.mcpc.json --resources
+mcpdiff inspect snapshot.mcpc.json --prompts
 mcpdiff inspect snapshot.mcpc.json --schema create_contact
 ```
 
@@ -257,6 +261,9 @@ mcpdiff inspect snapshot.mcpc.json --schema create_contact
 All commands that connect to a live server accept these transport options:
 
 ```bash
+# Stdio: command, arguments, and environment variables
+mcpdiff snapshot --command node --args dist/index.js --env API_KEY=secret -o snapshot.mcpc.json
+
 # SSE transport (instead of default streamable-http)
 mcpdiff snapshot --url http://localhost:3000/sse --sse -o snapshot.mcpc.json
 
@@ -270,11 +277,27 @@ mcpdiff snapshot --url http://localhost:3000/mcp \
 | Flag | Description |
 |------|-------------|
 | `--command <cmd>` | Server command to run via stdio transport |
+| `--args <args...>` | Arguments for the server command |
+| `--env <pairs...>` | Environment variables for the server as `KEY=VALUE` pairs |
 | `--url <url>` | Server URL for streamable-http or SSE transport |
 | `--sse` | Use SSE transport instead of streamable-http (requires `--url`) |
 | `--header <header...>` | Custom HTTP headers as `"Key: Value"` (repeatable) |
 | `--config <path>` | Path to `mcp.json` config file |
 | `--server <name>` | Server name from config file |
+
+## Global Options
+
+Available on every command, in any position (`mcpdiff check --format json` and `mcpdiff --format json check` both work):
+
+| Flag | Description |
+|------|-------------|
+| `--format <format>` | Output format: `terminal` \| `json` \| `markdown` (default: terminal on a TTY, json otherwise) |
+| `-o, --output <path>` | Write output to a file instead of stdout |
+| `--no-color` | Disable colored output |
+| `--quiet` | Suppress non-essential output |
+| `--verbose` | Show detailed information |
+| `--project <path>` | Path to `mcpcontracts.json` (default: discovered by walking up from the CWD) |
+| `-V, --version` | Print the CLI version |
 
 ## Project Config (`mcpcontracts.json`)
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ MCP servers expose tools, resources, and prompts to AI agents. These interfaces 
 
 ```bash
 # Capture a baseline snapshot of your MCP server
-npx @mcp-contracts/cli baseline update --command "node ./my-server/dist/index.js"
+npx @mcp-contracts/cli update --command "node ./my-server/dist/index.js"
 # → writes contracts/baseline.mcpc.json
 
-# Later, verify nothing has changed
-npx @mcp-contracts/cli baseline verify --command "node ./my-server/dist/index.js"
+# Later, check nothing has changed (locally, in CI, anywhere)
+npx @mcp-contracts/cli check --command "node ./my-server/dist/index.js"
 
 # Or diff two snapshots manually
 npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v1.mcpc.json
@@ -33,7 +33,7 @@ npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v2
 npx @mcp-contracts/cli diff v1.mcpc.json v2.mcpc.json
 ```
 
-Tired of repeating `--command`? Put it in a [project config](#project-config-mcpcontractsjson) once and run `mcpdiff baseline verify` with zero flags.
+Tired of repeating `--command`? Put it in a [project config](#project-config-mcpcontractsjson) once and run `mcpdiff check` with zero flags.
 
 Output:
 ```
@@ -47,6 +47,8 @@ Output:
 ```
 
 ## Commands
+
+> Migrating from an older version? `ci`, `watch`, `baseline verify`, `baseline update`, and `diff --live` still work but are deprecated — they are replaced by `check` (with `--watch`) and `update`, and will be removed in a future release.
 
 ### `mcpdiff snapshot`
 
@@ -72,9 +74,6 @@ Compares two snapshots and classifies every change as breaking, warning, or safe
 
 ```bash
 mcpdiff diff before.mcpc.json after.mcpc.json
-
-# Diff a baseline against a live server
-mcpdiff diff baseline.mcpc.json --live --command "node server.js"
 
 # Fail CI on warnings too (stricter)
 mcpdiff diff before.mcpc.json after.mcpc.json --fail-on warning
@@ -119,57 +118,53 @@ mcpdiff --format mermaid graph --config ./mcp.json
 mcpdiff --format dot graph --config ./mcp.json
 ```
 
-### `mcpdiff baseline`
+### `mcpdiff check`
 
-Manage contract baselines — capture and verify snapshots against a committed baseline.
-
-```bash
-# Capture a baseline (default: contracts/baseline.mcpc.json)
-mcpdiff baseline update --command "node server.js"
-
-# Write to a custom path
-mcpdiff -o custom/path.mcpc.json baseline update --command "node server.js"
-
-# Verify the server still matches the baseline
-mcpdiff baseline verify --command "node server.js"
-mcpdiff baseline verify --baseline custom/path.mcpc.json --url http://localhost:3000/mcp
-```
-
-### `mcpdiff ci`
-
-All-in-one CI command: captures a snapshot, diffs against a baseline, outputs the report, and sets the exit code.
+The one command for "does the live server still match the baseline": captures a snapshot, diffs it against the baseline, reports, and sets the exit code. Works the same locally, in CI, and in watch mode.
 
 ```bash
-# Basic usage
-mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js"
+# Check against the default baseline (contracts/baseline.mcpc.json)
+mcpdiff check --command "node server.js"
+
+# With a project config, zero flags
+mcpdiff check
 
 # Fail on warnings too (stricter)
-mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --fail-on warning
+mcpdiff check --fail-on warning
 
 # Only show breaking changes
-mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --severity breaking
+mcpdiff check --severity breaking
+
+# Re-run on file changes during development
+mcpdiff check --watch --watch-paths src --debounce 1000
+
+# Require a valid signature on the baseline before diffing
+mcpdiff check --verify-signature --signature-key ./public.pem
 
 # Send results to a webhook
-mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node server.js" --webhook https://example.com/hook
+mcpdiff check --webhook https://example.com/hook
 ```
 
-Auto-detects CI environments (GitHub Actions, GitLab CI, CircleCI) and selects the appropriate output format. Writes to `GITHUB_STEP_SUMMARY` when running in GitHub Actions.
+Auto-detects CI environments (GitHub Actions, GitLab CI, CircleCI) and selects the appropriate output format. Writes to `GITHUB_STEP_SUMMARY` when running in GitHub Actions. When the live contract is unchanged (matching content hashes), the diff engine is skipped entirely.
 
-### `mcpdiff watch`
+**Exit codes:** `0` = clean, `1` = changes at or above the `--fail-on` threshold, `2` = error.
 
-Watch for file changes and re-diff against a baseline on every change. Useful during development.
+### `mcpdiff update`
+
+Captures the live server and writes the baseline. The counterpart to `check`.
 
 ```bash
-mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js"
+# Write the default baseline (contracts/baseline.mcpc.json)
+mcpdiff update --command "node server.js"
 
-# Watch specific paths with custom debounce
-mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js" \
-  --watch-paths src lib --debounce 1000
+# With a project config, zero flags
+mcpdiff update
 
-# Send diffs to a webhook on each cycle
-mcpdiff watch --baseline contracts/baseline.mcpc.json --command "node server.js" \
-  --webhook https://example.com/hook
+# Write to a custom path
+mcpdiff update --baseline custom/path.mcpc.json --command "node server.js"
 ```
+
+For ad-hoc snapshots that are not baselines, use `mcpdiff snapshot -o <file>`.
 
 ### `mcpdiff sign`
 
@@ -270,15 +265,14 @@ Instead of repeating transport and baseline flags on every invocation, put them 
 With the config in place, the repeated commands need no flags at all:
 
 ```bash
-mcpdiff baseline update        # knows the server + baseline path
-mcpdiff baseline verify        # zero flags locally
-mcpdiff ci                     # zero flags in CI
-mcpdiff watch                  # zero flags in dev
+mcpdiff update                 # knows the server + baseline path
+mcpdiff check                  # zero flags locally and in CI
+mcpdiff check --watch          # zero flags in dev
 ```
 
-The config is read by every command that connects to a live server: `snapshot`, `diff --live`, `baseline update`, `baseline verify`, `ci`, and `watch`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`, `verify-hash`) ignore it.
+The config is read by every command that connects to a live server: `check`, `update`, and `snapshot`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`, `verify-hash`) ignore it.
 
-**Precedence:** explicit CLI flags > config file > built-in defaults. Passing any transport flag (`--command`, `--url`, `--config`, …) ignores the config's `server` block entirely — the two sources are never partially merged. `failOn` applies to `ci` and `watch`; the `watch` block applies to `watch` only.
+**Precedence:** explicit CLI flags > config file > built-in defaults. Passing any transport flag (`--command`, `--url`, `--config`, …) ignores the config's `server` block entirely — the two sources are never partially merged. `failOn` and the `watch` block apply to `check`.
 
 **Paths** in the config (`baseline`, `watch.paths`, `server.config`) are resolved relative to the config file's directory, so commands behave the same from any subdirectory.
 
@@ -321,7 +315,7 @@ jobs:
 
 ### CLI in CI
 
-Use `mcpdiff ci` directly in any CI system:
+Use `mcpdiff check` directly in any CI system:
 
 ```yaml
 # .github/workflows/mcp-contract.yml
@@ -333,18 +327,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g @mcp-contracts/cli
-      - run: mcpdiff ci --baseline contracts/baseline.mcpc.json --command "node dist/index.js"
+      - run: mcpdiff check --baseline contracts/baseline.mcpc.json --command "node dist/index.js"
+
+      # Or with a committed mcpcontracts.json, zero flags
+      - run: mcpdiff check
 
       # Or with signature verification
       - run: >
-          mcpdiff ci
+          mcpdiff check
           --baseline contracts/baseline.mcpc.json
           --command "node dist/index.js"
           --verify-signature
           --signature-key ./public.pem
 ```
 
-The `ci` command auto-detects the CI environment and selects the right output format (markdown for GitHub Actions, JSON otherwise). It also writes to `GITHUB_STEP_SUMMARY` automatically.
+The `check` command auto-detects the CI environment and selects the right output format (markdown for GitHub Actions, JSON otherwise). It also writes to `GITHUB_STEP_SUMMARY` automatically.
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -19,21 +19,23 @@ MCP servers expose tools, resources, and prompts to AI agents. These interfaces 
 ## Quick Start
 
 ```bash
-# Capture a baseline snapshot of your MCP server
-npx @mcp-contracts/cli update --command "node ./my-server/dist/index.js"
-# → writes contracts/baseline.mcpc.json
+# One-command setup: writes mcpcontracts.json and captures the baseline
+npx @mcp-contracts/cli init --command node --args ./my-server/dist/index.js
 
-# Later, check nothing has changed (locally, in CI, anywhere)
-npx @mcp-contracts/cli check --command "node ./my-server/dist/index.js"
+# From then on — zero flags, locally and in CI
+npx @mcp-contracts/cli check
+```
 
-# Or diff two snapshots manually
+`init` writes a [project config](#project-config-mcpcontractsjson) so every later invocation knows your server and baseline, captures `contracts/baseline.mcpc.json`, and prints the CI snippet to paste into your workflow.
+
+You can also diff two snapshots manually:
+
+```bash
 npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v1.mcpc.json
 # ... make changes ...
 npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v2.mcpc.json
 npx @mcp-contracts/cli diff v1.mcpc.json v2.mcpc.json
 ```
-
-Tired of repeating `--command`? Put it in a [project config](#project-config-mcpcontractsjson) once and run `mcpdiff check` with zero flags.
 
 Output:
 ```
@@ -117,6 +119,25 @@ mcpdiff graph --config ./mcp.json
 mcpdiff --format mermaid graph --config ./mcp.json
 mcpdiff --format dot graph --config ./mcp.json
 ```
+
+### `mcpdiff init`
+
+One-command onboarding: writes `mcpcontracts.json`, captures the initial baseline, and prints next steps including a copy-pasteable CI workflow.
+
+```bash
+# Non-interactive (also works in scripts/CI)
+mcpdiff init --command node --args dist/index.js
+mcpdiff init --url http://localhost:3000/mcp
+mcpdiff init --config ./mcp.json --server my-server
+
+# Interactive: offers servers from ./mcp.json, or asks for a command/URL
+mcpdiff init
+
+# Overwrite an existing mcpcontracts.json
+mcpdiff init --force --command node --args dist/index.js
+```
+
+Without a TTY, missing information exits with code `2` instead of prompting. Nothing is written unless the initial capture succeeds.
 
 ### `mcpdiff check`
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v2
 npx @mcp-contracts/cli diff v1.mcpc.json v2.mcpc.json
 ```
 
+Tired of repeating `--command`? Put it in a [project config](#project-config-mcpcontractsjson) once and run `mcpdiff baseline verify` with zero flags.
+
 Output:
 ```
   mcp-contracts diff — acme-server v1.0.0 → v1.1.0
@@ -244,6 +246,43 @@ mcpdiff snapshot --url http://localhost:3000/mcp \
 | `--header <header...>` | Custom HTTP headers as `"Key: Value"` (repeatable) |
 | `--config <path>` | Path to `mcp.json` config file |
 | `--server <name>` | Server name from config file |
+
+## Project Config (`mcpcontracts.json`)
+
+Instead of repeating transport and baseline flags on every invocation, put them in an `mcpcontracts.json` at your project root. It is discovered by walking up from the current directory (like `tsconfig.json`), or passed explicitly with the global `--project <path>` option.
+
+```jsonc
+{
+  // How to reach your server — exactly one of the three transport shapes:
+  "server": {
+    "command": "node",
+    "args": ["dist/index.js"],
+    "env": { "API_KEY": "..." }
+    // or: "url": "http://localhost:3000/mcp", "sse": true, "headers": { "Authorization": "..." }
+    // or: "config": "./mcp.json", "name": "my-server"
+  },
+  "baseline": "contracts/baseline.mcpc.json",
+  "failOn": "breaking",
+  "watch": { "paths": ["src"], "debounce": 500 }
+}
+```
+
+With the config in place, the repeated commands need no flags at all:
+
+```bash
+mcpdiff baseline update        # knows the server + baseline path
+mcpdiff baseline verify        # zero flags locally
+mcpdiff ci                     # zero flags in CI
+mcpdiff watch                  # zero flags in dev
+```
+
+The config is read by every command that connects to a live server: `snapshot`, `diff --live`, `baseline update`, `baseline verify`, `ci`, and `watch`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`, `verify-hash`) ignore it.
+
+**Precedence:** explicit CLI flags > config file > built-in defaults. Passing any transport flag (`--command`, `--url`, `--config`, …) ignores the config's `server` block entirely — the two sources are never partially merged. `failOn` applies to `ci` and `watch`; the `watch` block applies to `watch` only.
+
+**Paths** in the config (`baseline`, `watch.paths`, `server.config`) are resolved relative to the config file's directory, so commands behave the same from any subdirectory.
+
+**Validation** is strict: unknown keys are an error (catching typos like `"failon"`), and an invalid config exits with code `2` and a message naming the file and the offending key — even when flags would have overridden it.
 
 ## Why Description Changes are Warnings
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ Output:
 
 > Migrating from an older version? `ci`, `watch`, `baseline verify`, `baseline update`, `diff --live`, and `verify-hash` still work but are deprecated — they are replaced by `check` (with `--watch`), `update`, and `verify` (without `--key`), and will be removed in a future release.
 
+### `mcpdiff test`
+
+Runs the contract test suite from `@mcp-contracts/test` against a live server: schema conformance (every tool in the contract exists with a matching schema) plus boundary input tests.
+
+```bash
+# With a project config, zero arguments
+mcpdiff test
+
+# Explicit contract and transport
+mcpdiff test contract.mcpc.json --command node --args server.js
+mcpdiff test contract.mcpc.json --url http://localhost:3000/mcp --allow-extra-tools
+
+# Tune the suite
+mcpdiff test --no-boundary --skip-tools delete_contact --timeout 60000
+```
+
+**Exit codes:** `0` = all pass, `1` = failures, `2` = error. The standalone `mcp-test` bin still works but points here; the `@mcp-contracts/test` package remains the library for vitest integration.
+
 ### `mcpdiff snapshot`
 
 Connects to an MCP server and captures its complete tool/resource/prompt interface as a `.mcpc.json` file.
@@ -365,6 +383,7 @@ The `check` command auto-detects the CI environment and selects the right output
 |---------|-------------|
 | [`@mcp-contracts/core`](./packages/core) | Snapshot types, diff engine, classification logic |
 | [`@mcp-contracts/cli`](./packages/cli) | The `mcpdiff` CLI tool |
+| [`@mcp-contracts/test`](./packages/test) | Contract testing library: conformance + boundary runner, vitest matchers |
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@mcp-contracts/core": "workspace:*",
+    "@mcp-contracts/test": "workspace:^",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "cli-table3": "^0.6.0",
     "commander": "^14.0.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-contracts/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "CLI tool for capturing and diffing MCP tool schemas",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/fixtures/fixture-server.mjs
+++ b/packages/cli/src/__tests__/fixtures/fixture-server.mjs
@@ -1,0 +1,35 @@
+/**
+ * Minimal stdio MCP server used by the CLI integration tests.
+ *
+ * Uses the low-level Server API with raw JSON schemas so the fixture only
+ * depends on @modelcontextprotocol/sdk (a direct dependency of the CLI).
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server(
+  { name: "fixture-server", version: "1.0.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "echo",
+      description: "Echo a message back",
+      inputSchema: {
+        type: "object",
+        properties: { message: { type: "string", description: "Message to echo" } },
+        required: ["message"],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => ({
+  content: [{ type: "text", text: String(request.params.arguments?.message ?? "") }],
+}));
+
+await server.connect(new StdioServerTransport());

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -613,3 +613,55 @@ describe("integration: init", () => {
     expect(forced.exitCode).toBe(0);
   });
 });
+
+describe("integration: test command", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let projectDir: string;
+
+  beforeEach(async () => {
+    projectDir = mkdtempSync(join(tmpdir(), "mcpc-test-cmd-"));
+    const init = await runCliIn(projectDir, "init", "--command", "node", "--args", FIXTURE_SERVER);
+    expect(init.exitCode).toBe(0);
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("runs the contract test suite with zero arguments via the project config", async () => {
+    const { stdout, exitCode } = await runCliIn(projectDir, "test", "--format", "json");
+    expect(exitCode).toBe(0);
+    const report = JSON.parse(stdout);
+    expect(report.summary.failed).toBe(0);
+    expect(report.summary.errors).toBe(0);
+    expect(report.summary.passed).toBeGreaterThan(0);
+  });
+
+  it("exits 1 when the live server does not conform to the contract", async () => {
+    const baselinePath = join(projectDir, "contracts", "baseline.mcpc.json");
+    const baseline = JSON.parse(readFileSync(baselinePath, "utf-8"));
+    baseline.tools.echo.description = "A different description than the server reports";
+    writeFileSync(baselinePath, JSON.stringify(baseline, null, 2), "utf-8");
+
+    const { stdout, exitCode } = await runCliIn(projectDir, "test", "--format", "json");
+    expect(exitCode).toBe(1);
+    const report = JSON.parse(stdout);
+    expect(report.summary.failed).toBeGreaterThan(0);
+  });
+
+  it("supports explicit contract path and transport flags", async () => {
+    const { exitCode } = await runCliIn(
+      projectDir,
+      "test",
+      join(projectDir, "contracts", "baseline.mcpc.json"),
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+      "--no-boundary",
+      "--format",
+      "json",
+    );
+    expect(exitCode).toBe(0);
+  });
+});

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -1,7 +1,9 @@
 import { execFile } from "node:child_process";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 
@@ -21,8 +23,27 @@ const V2_WARNING = resolve(FIXTURES_DIR, "server-v2-warning.mcpc.json");
 async function runCli(
   ...args: string[]
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return runCliIn(process.cwd(), ...args);
+}
+
+/**
+ * Runs the CLI with the given arguments from a specific working directory.
+ *
+ * Strips GITHUB_STEP_SUMMARY so `ci` runs don't write to a real step summary
+ * when the test suite itself runs in GitHub Actions.
+ *
+ * @param cwd - Working directory for the CLI process.
+ * @param args - CLI arguments to pass.
+ * @returns stdout, stderr, and exitCode.
+ */
+async function runCliIn(
+  cwd: string,
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const env = { ...process.env };
+  delete env["GITHUB_STEP_SUMMARY"];
   try {
-    const { stdout, stderr } = await execFileAsync("node", [CLI_PATH, ...args]);
+    const { stdout, stderr } = await execFileAsync("node", [CLI_PATH, ...args], { cwd, env });
     return { stdout, stderr, exitCode: 0 };
   } catch (err: unknown) {
     const e = err as { stdout: string; stderr: string; code: number };
@@ -227,5 +248,134 @@ describe("integration: CLI", () => {
       expect(stdout).toContain("--sse");
       expect(stdout).toContain("--header");
     });
+  });
+});
+
+describe("integration: project config (mcpcontracts.json)", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "mcpc-integration-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeProjectConfig(config: unknown): void {
+    writeFileSync(join(projectDir, "mcpcontracts.json"), JSON.stringify(config, null, 2), "utf-8");
+  }
+
+  it("root --help shows the --project option", async () => {
+    const { stdout, exitCode } = await runCli("--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--project");
+  });
+
+  it("runs baseline update, verify, and ci with zero flags", async () => {
+    writeProjectConfig({
+      server: { command: "node", args: [FIXTURE_SERVER] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+
+    const update = await runCliIn(projectDir, "baseline", "update");
+    expect(update.exitCode).toBe(0);
+    expect(existsSync(join(projectDir, "contracts", "baseline.mcpc.json"))).toBe(true);
+
+    const verify = await runCliIn(projectDir, "baseline", "verify");
+    expect(verify.exitCode).toBe(0);
+    expect(verify.stderr).toContain("Baseline verified");
+
+    const ci = await runCliIn(projectDir, "ci", "--format", "json");
+    expect(ci.exitCode).toBe(0);
+    const report = JSON.parse(ci.stdout);
+    expect(report.summary).toMatchObject({ breaking: 0, warning: 0, safe: 0 });
+  });
+
+  it("discovers the config from a subdirectory", async () => {
+    writeProjectConfig({
+      server: { command: "node", args: [FIXTURE_SERVER] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+    const sub = join(projectDir, "src", "nested");
+    mkdirSync(sub, { recursive: true });
+
+    const update = await runCliIn(sub, "baseline", "update");
+    expect(update.exitCode).toBe(0);
+    expect(existsSync(join(projectDir, "contracts", "baseline.mcpc.json"))).toBe(true);
+
+    const verify = await runCliIn(sub, "baseline", "verify");
+    expect(verify.exitCode).toBe(0);
+  });
+
+  it("uses --project to load a config outside the cwd", async () => {
+    writeProjectConfig({
+      server: { command: "node", args: [FIXTURE_SERVER] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+    await runCliIn(projectDir, "baseline", "update");
+
+    const elsewhere = mkdtempSync(join(tmpdir(), "mcpc-elsewhere-"));
+    try {
+      const verify = await runCliIn(
+        elsewhere,
+        "baseline",
+        "verify",
+        "--project",
+        join(projectDir, "mcpcontracts.json"),
+      );
+      expect(verify.exitCode).toBe(0);
+    } finally {
+      rmSync(elsewhere, { recursive: true, force: true });
+    }
+  });
+
+  it("lets explicit flags override the config baseline", async () => {
+    writeProjectConfig({
+      server: { command: "node", args: [FIXTURE_SERVER] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+    await runCliIn(projectDir, "baseline", "update");
+
+    const { stderr, exitCode } = await runCliIn(
+      projectDir,
+      "baseline",
+      "verify",
+      "--baseline",
+      "missing.mcpc.json",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("missing.mcpc.json");
+  });
+
+  it("exits 2 on an invalid config, naming the file and key", async () => {
+    writeProjectConfig({ failon: "breaking" });
+    const { stderr, exitCode } = await runCliIn(projectDir, "snapshot");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("failon");
+    expect(stderr).toContain("mcpcontracts.json");
+  });
+
+  it("exits 2 on an invalid config even when flags specify the transport", async () => {
+    writeProjectConfig({ server: {} });
+    const { stderr, exitCode } = await runCliIn(
+      projectDir,
+      "snapshot",
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("mcpcontracts.json");
+  });
+
+  it("ci without a baseline anywhere explains both options", async () => {
+    writeProjectConfig({ server: { command: "node", args: [FIXTURE_SERVER] } });
+    const { stderr, exitCode } = await runCliIn(projectDir, "ci");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--baseline");
+    expect(stderr).toContain("mcpcontracts.json");
   });
 });

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -55,14 +55,20 @@ describe("integration: CLI", () => {
   describe("--help", () => {
     it("exits 0 and shows usage info", async () => {
       const { stdout, exitCode } = await runCli("--help");
-      expect(exitCode).toBe(0);
       expect(stdout).toContain("mcpdiff");
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("check");
+      expect(stdout).toContain("update");
       expect(stdout).toContain("snapshot");
       expect(stdout).toContain("diff");
       expect(stdout).toContain("inspect");
-      expect(stdout).toContain("baseline");
-      expect(stdout).toContain("ci");
-      expect(stdout).toContain("watch");
+    });
+
+    it("hides deprecated commands from usage info", async () => {
+      const { stdout } = await runCli("--help");
+      expect(stdout).not.toMatch(/^ {2}ci\b/m);
+      expect(stdout).not.toMatch(/^ {2}watch\b/m);
+      expect(stdout).not.toMatch(/^ {2}baseline\b/m);
     });
   });
 
@@ -401,5 +407,91 @@ describe("integration: project config (mcpcontracts.json)", () => {
     expect(exitCode).toBe(2);
     expect(stderr).toContain("--baseline");
     expect(stderr).toContain("mcpcontracts.json");
+  });
+});
+
+describe("integration: check and update", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "mcpc-check-update-"));
+    writeFileSync(
+      join(projectDir, "mcpcontracts.json"),
+      JSON.stringify(
+        {
+          server: { command: "node", args: [FIXTURE_SERVER] },
+          baseline: "contracts/baseline.mcpc.json",
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("update then check succeed with zero flags", async () => {
+    const update = await runCliIn(projectDir, "update");
+    expect(update.exitCode).toBe(0);
+    expect(update.stderr).toContain("Baseline written to");
+    expect(existsSync(join(projectDir, "contracts", "baseline.mcpc.json"))).toBe(true);
+
+    const check = await runCliIn(projectDir, "check", "--format", "json");
+    expect(check.exitCode).toBe(0);
+    expect(check.stderr).toContain("Contract unchanged");
+    const report = JSON.parse(check.stdout);
+    expect(report.changes).toHaveLength(0);
+  });
+
+  it("check exits 2 when the baseline file is missing", async () => {
+    const { stderr, exitCode } = await runCliIn(projectDir, "check");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("baseline.mcpc.json");
+  });
+
+  it("check --help shows the full consolidated flag surface", async () => {
+    const { stdout, exitCode } = await runCli("check", "--help");
+    expect(exitCode).toBe(0);
+    for (const flag of [
+      "--baseline",
+      "--fail-on",
+      "--severity",
+      "--webhook",
+      "--verify-signature",
+      "--signature-key",
+      "--watch",
+      "--watch-paths",
+      "--debounce",
+      "--clear",
+      "--command",
+      "--url",
+    ]) {
+      expect(stdout).toContain(flag);
+    }
+  });
+
+  it("deprecated spellings still work and print a notice", async () => {
+    await runCliIn(projectDir, "update");
+
+    const baselineVerify = await runCliIn(projectDir, "baseline", "verify");
+    expect(baselineVerify.exitCode).toBe(0);
+    expect(baselineVerify.stderr).toContain("deprecated");
+    expect(baselineVerify.stderr).toContain("mcpdiff check");
+
+    const baselineUpdate = await runCliIn(projectDir, "baseline", "update");
+    expect(baselineUpdate.exitCode).toBe(0);
+    expect(baselineUpdate.stderr).toContain("mcpdiff update");
+
+    const ci = await runCliIn(projectDir, "ci", "--format", "json");
+    expect(ci.exitCode).toBe(0);
+    expect(ci.stderr).toContain("mcpdiff check");
+
+    const diffLive = await runCliIn(projectDir, "diff", "--live", "--format", "json");
+    expect(diffLive.exitCode).toBe(0);
+    expect(diffLive.stderr).toContain("mcpdiff check");
   });
 });

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -546,5 +546,70 @@ describe("integration: verify", () => {
     expect(JSON.parse(stdout).valid).toBe(true);
     expect(stderr).toContain("deprecated");
     expect(stderr).toContain("mcpdiff verify");
+  });
+});
+
+describe("integration: init", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "mcpc-init-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("initializes a project non-interactively and check passes", async () => {
+    const init = await runCliIn(projectDir, "init", "--command", "node", "--args", FIXTURE_SERVER);
+    expect(init.exitCode).toBe(0);
+    expect(init.stderr).toContain("Wrote mcpcontracts.json");
+    expect(init.stderr).toContain("mcp-contract.yml");
+    expect(init.stderr).toContain("mcpdiff check");
+
+    const config = JSON.parse(
+      readFileSync(join(projectDir, "mcpcontracts.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(config["baseline"]).toBe("contracts/baseline.mcpc.json");
+    expect(config["failOn"]).toBe("breaking");
+    expect(existsSync(join(projectDir, "contracts", "baseline.mcpc.json"))).toBe(true);
+
+    const check = await runCliIn(projectDir, "check", "--format", "json");
+    expect(check.exitCode).toBe(0);
+    expect(check.stderr).toContain("Contract unchanged");
+  });
+
+  it("exits 2 instead of hanging when non-interactive and underspecified", async () => {
+    const { stderr, exitCode } = await runCliIn(projectDir, "init");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--command");
+  });
+
+  it("refuses to overwrite without --force, then overwrites with it", async () => {
+    const first = await runCliIn(projectDir, "init", "--command", "node", "--args", FIXTURE_SERVER);
+    expect(first.exitCode).toBe(0);
+
+    const second = await runCliIn(
+      projectDir,
+      "init",
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+    );
+    expect(second.exitCode).toBe(2);
+    expect(second.stderr).toContain("--force");
+
+    const forced = await runCliIn(
+      projectDir,
+      "init",
+      "--force",
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+    );
+    expect(forced.exitCode).toBe(0);
   });
 });

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -77,7 +77,7 @@ describe("integration: CLI", () => {
     it("exits 0 and prints version", async () => {
       const { stdout, exitCode } = await runCli("--version");
       expect(exitCode).toBe(0);
-      expect(stdout.trim()).toBe("0.6.0");
+      expect(stdout.trim()).toBe("0.7.0");
     });
   });
 

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -309,6 +309,30 @@ describe("integration: project config (mcpcontracts.json)", () => {
     expect(verify.exitCode).toBe(0);
   });
 
+  it("spawns relative stdio commands from the config directory", async () => {
+    // A launcher that only resolves if the server spawns with the config
+    // file's directory as its cwd, not the invoking subdirectory.
+    const launcher = join(projectDir, "srv.mjs");
+    writeFileSync(
+      launcher,
+      `await import(${JSON.stringify(`file://${FIXTURE_SERVER}`)});\n`,
+      "utf-8",
+    );
+    writeProjectConfig({
+      server: { command: "node", args: ["srv.mjs"] },
+      baseline: "contracts/baseline.mcpc.json",
+    });
+    const sub = join(projectDir, "deeply", "nested");
+    mkdirSync(sub, { recursive: true });
+
+    const update = await runCliIn(sub, "baseline", "update");
+    expect(update.exitCode).toBe(0);
+
+    const verify = await runCliIn(sub, "baseline", "verify");
+    expect(verify.exitCode).toBe(0);
+    expect(verify.stderr).toContain("Baseline verified");
+  });
+
   it("uses --project to load a config outside the cwd", async () => {
     writeProjectConfig({
       server: { command: "node", args: [FIXTURE_SERVER] },

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -69,6 +69,7 @@ describe("integration: CLI", () => {
       expect(stdout).not.toMatch(/^ {2}ci\b/m);
       expect(stdout).not.toMatch(/^ {2}watch\b/m);
       expect(stdout).not.toMatch(/^ {2}baseline\b/m);
+      expect(stdout).not.toMatch(/^ {2}verify-hash\b/m);
     });
   });
 
@@ -493,5 +494,57 @@ describe("integration: check and update", () => {
     const diffLive = await runCliIn(projectDir, "diff", "--live", "--format", "json");
     expect(diffLive.exitCode).toBe(0);
     expect(diffLive.stderr).toContain("mcpdiff check");
+  });
+});
+
+describe("integration: verify", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let workDir: string;
+  let snapshotPath: string;
+
+  beforeEach(async () => {
+    workDir = mkdtempSync(join(tmpdir(), "mcpc-verify-"));
+    snapshotPath = join(workDir, "snapshot.mcpc.json");
+    const { exitCode } = await runCliIn(
+      workDir,
+      "snapshot",
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+      "-o",
+      snapshotPath,
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("checks only the content hash without --key and says so", async () => {
+    const json = await runCli("verify", snapshotPath, "--format", "json");
+    expect(json.exitCode).toBe(0);
+    const result = JSON.parse(json.stdout);
+    expect(result.valid).toBe(true);
+    expect(result.checks).toEqual(["hash"]);
+
+    const terminal = await runCli("verify", snapshotPath, "--format", "terminal");
+    expect(terminal.exitCode).toBe(0);
+    expect(terminal.stdout).toContain("Content hash verified");
+    expect(terminal.stderr).toContain("only the content hash was checked");
+  });
+
+  it("verify-hash still works as a deprecated alias", async () => {
+    const { stdout, stderr, exitCode } = await runCli(
+      "verify-hash",
+      snapshotPath,
+      "--format",
+      "json",
+    );
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).valid).toBe(true);
+    expect(stderr).toContain("deprecated");
+    expect(stderr).toContain("mcpdiff verify");
   });
 });

--- a/packages/cli/src/baseline-signature.ts
+++ b/packages/cli/src/baseline-signature.ts
@@ -1,0 +1,85 @@
+/**
+ * Baseline signature verification, shared by `check` and the deprecated `ci`.
+ */
+
+import { readFileSync } from "node:fs";
+import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import { parseSignatureFile, verifySignature } from "@mcp-contracts/core";
+import { deriveSignaturePath } from "./commands/sign.js";
+import { CliExitError } from "./utils.js";
+
+/**
+ * Verifies the baseline snapshot's signature before diffing.
+ *
+ * @param baseline - The parsed baseline snapshot.
+ * @param baselinePath - File path to the baseline (used to derive sig path).
+ * @param signatureKeyOption - The --signature-key option value, if provided.
+ * @param quiet - Whether to suppress non-essential output.
+ */
+export function verifyBaselineSignature(
+  baseline: MCPContractSnapshot,
+  baselinePath: string,
+  signatureKeyOption: string | undefined,
+  quiet: boolean,
+): void {
+  const keyPem = resolveSignatureKey(signatureKeyOption);
+  const sigPath = deriveSignaturePath(baselinePath);
+
+  let sigJson: string;
+  try {
+    sigJson = readFileSync(sigPath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read baseline signature file "${sigPath}": ${message}`);
+  }
+
+  const sig = parseSignatureFile(sigJson);
+  const result = verifySignature(baseline, sig, keyPem);
+
+  if (!result.valid) {
+    process.stderr.write(`Baseline signature verification failed: ${result.error}\n`);
+    throw new CliExitError(2);
+  }
+
+  if (!quiet) {
+    process.stderr.write("Baseline signature verified\n");
+  }
+}
+
+/**
+ * Resolves the public key PEM for signature verification.
+ *
+ * Checks the `--signature-key` option first, then the `MCP_SIGNATURE_KEY`
+ * environment variable. The env var can contain PEM content directly
+ * (starts with "-----BEGIN") or a file path.
+ *
+ * @param optionValue - The --signature-key option value, if provided.
+ * @returns The PEM string for the public key.
+ */
+function resolveSignatureKey(optionValue: string | undefined): string {
+  if (optionValue) {
+    try {
+      return readFileSync(optionValue, "utf-8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to read signature key file "${optionValue}": ${message}`);
+    }
+  }
+
+  const envValue = process.env["MCP_SIGNATURE_KEY"];
+  if (envValue) {
+    if (envValue.startsWith("-----BEGIN")) {
+      return envValue;
+    }
+    try {
+      return readFileSync(envValue, "utf-8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to read key from MCP_SIGNATURE_KEY path "${envValue}": ${message}`);
+    }
+  }
+
+  throw new Error(
+    "--verify-signature requires --signature-key <path> or MCP_SIGNATURE_KEY environment variable",
+  );
+}

--- a/packages/cli/src/commands/baseline.test.ts
+++ b/packages/cli/src/commands/baseline.test.ts
@@ -238,12 +238,13 @@ describe("baseline command", () => {
       expect(stderrData).toContain("Failed to read snapshot file");
     });
 
-    it("uses default baseline path", () => {
+    it("has no commander default for --baseline so the project config can supply it", () => {
       const program = createProgram();
       const baselineCmd = program.commands.find((c) => c.name() === "baseline");
       const verifyCmd = baselineCmd?.commands.find((c) => c.name() === "verify");
       const baselineOpt = verifyCmd?.options.find((o) => o.long === "--baseline");
-      expect(baselineOpt?.defaultValue).toBe("contracts/baseline.mcpc.json");
+      expect(baselineOpt?.defaultValue).toBeUndefined();
+      expect(baselineOpt?.description).toContain("contracts/baseline.mcpc.json");
     });
   });
 });

--- a/packages/cli/src/commands/baseline.ts
+++ b/packages/cli/src/commands/baseline.ts
@@ -13,6 +13,7 @@ import {
   CliExitError,
   getRootOpts,
   handleErrors,
+  printDeprecationNotice,
   readSnapshotFile,
   writeOutput,
 } from "../utils.js";
@@ -38,6 +39,9 @@ export function createBaselineUpdateCommand(): Command {
     handleErrors(async (options: Record<string, unknown>) => {
       const rootOpts = getRootOpts(cmd);
       const quiet = rootOpts["quiet"] === true;
+      if (!quiet) {
+        printDeprecationNotice("mcpdiff baseline update", "mcpdiff update");
+      }
       const project = loadProjectConfig(rootOpts["project"] as string | undefined);
       const outputPath =
         resolveBaselinePath(rootOpts["output"] as string | undefined, project) ??
@@ -80,6 +84,9 @@ export function createBaselineVerifyCommand(): Command {
       handleErrors(async (options: Record<string, unknown>) => {
         const rootOpts = getRootOpts(cmd);
         const quiet = rootOpts["quiet"] === true;
+        if (!quiet) {
+          printDeprecationNotice("mcpdiff baseline verify", "mcpdiff check");
+        }
         const project = loadProjectConfig(rootOpts["project"] as string | undefined);
         const baselinePath =
           resolveBaselinePath(options["baseline"] as string | undefined, project) ??

--- a/packages/cli/src/commands/baseline.ts
+++ b/packages/cli/src/commands/baseline.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import { diffSnapshots } from "@mcp-contracts/core";
 import { Command } from "commander";
 import {
+  DEFAULT_BASELINE_PATH,
   loadProjectConfig,
   resolveBaselinePath,
   resolveTransportOrProject,
@@ -16,8 +17,6 @@ import {
   writeOutput,
 } from "../utils.js";
 import { captureSnapshot } from "./capture.js";
-
-const DEFAULT_BASELINE_PATH = "contracts/baseline.mcpc.json";
 
 /**
  * Creates the `baseline update` subcommand.

--- a/packages/cli/src/commands/baseline.ts
+++ b/packages/cli/src/commands/baseline.ts
@@ -2,33 +2,29 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { diffSnapshots } from "@mcp-contracts/core";
 import { Command } from "commander";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
-import { CliExitError, handleErrors, readSnapshotFile, writeOutput } from "../utils.js";
+import {
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import {
+  CliExitError,
+  getRootOpts,
+  handleErrors,
+  readSnapshotFile,
+  writeOutput,
+} from "../utils.js";
 import { captureSnapshot } from "./capture.js";
 
 const DEFAULT_BASELINE_PATH = "contracts/baseline.mcpc.json";
 
 /**
- * Resolves the root program options from a deeply nested subcommand.
- *
- * @param cmd - The current Command instance.
- * @returns The root program's parsed options.
- */
-function getRootOpts(cmd: Command): Record<string, unknown> {
-  let current: Command | null = cmd;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
-}
-
-/**
  * Creates the `baseline update` subcommand.
  *
  * Captures a snapshot from a live server and writes it to a baseline path.
- * Uses the global --output option from the root program, defaulting to
- * contracts/baseline.mcpc.json if not specified.
+ * The path comes from the global --output option, then the project config's
+ * "baseline", then contracts/baseline.mcpc.json.
  *
  * @returns A Commander Command instance.
  */
@@ -43,19 +39,12 @@ export function createBaselineUpdateCommand(): Command {
     handleErrors(async (options: Record<string, unknown>) => {
       const rootOpts = getRootOpts(cmd);
       const quiet = rootOpts["quiet"] === true;
-      const outputPath = (rootOpts["output"] as string | undefined) ?? DEFAULT_BASELINE_PATH;
+      const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+      const outputPath =
+        resolveBaselinePath(rootOpts["output"] as string | undefined, project) ??
+        DEFAULT_BASELINE_PATH;
 
-      const transportOpts: TransportOptions = {
-        command: options["command"] as string | undefined,
-        url: options["url"] as string | undefined,
-        config: options["config"] as string | undefined,
-        server: options["server"] as string | undefined,
-        args: options["args"] as string[] | undefined,
-        env: options["env"] as string[] | undefined,
-        sse: options["sse"] === true ? true : undefined,
-        header: options["header"] as string[] | undefined,
-      };
-      const config = resolveTransport(transportOpts);
+      const config = resolveTransportOrProject(options, project);
 
       const { snapshot } = await captureSnapshot({ transport: config, quiet });
 
@@ -86,47 +75,42 @@ export function createBaselineVerifyCommand(): Command {
 
   addTransportOptions(cmd);
 
-  cmd.option("--baseline <path>", "Path to baseline file", DEFAULT_BASELINE_PATH).action(
-    handleErrors(async (options: Record<string, unknown>) => {
-      const rootOpts = getRootOpts(cmd);
-      const quiet = rootOpts["quiet"] === true;
-      const baselinePath = (options["baseline"] as string) ?? DEFAULT_BASELINE_PATH;
+  cmd
+    .option("--baseline <path>", `Path to baseline file (default: "${DEFAULT_BASELINE_PATH}")`)
+    .action(
+      handleErrors(async (options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const quiet = rootOpts["quiet"] === true;
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+        const baselinePath =
+          resolveBaselinePath(options["baseline"] as string | undefined, project) ??
+          DEFAULT_BASELINE_PATH;
 
-      const baseline = readSnapshotFile(baselinePath);
+        const baseline = readSnapshotFile(baselinePath);
 
-      const transportOpts: TransportOptions = {
-        command: options["command"] as string | undefined,
-        url: options["url"] as string | undefined,
-        config: options["config"] as string | undefined,
-        server: options["server"] as string | undefined,
-        args: options["args"] as string[] | undefined,
-        env: options["env"] as string[] | undefined,
-        sse: options["sse"] === true ? true : undefined,
-        header: options["header"] as string[] | undefined,
-      };
-      const config = resolveTransport(transportOpts);
+        const config = resolveTransportOrProject(options, project);
 
-      const { snapshot: current } = await captureSnapshot({ transport: config, quiet });
+        const { snapshot: current } = await captureSnapshot({ transport: config, quiet });
 
-      if (baseline.contentHash === current.contentHash) {
-        if (!quiet) {
-          process.stderr.write("Baseline verified: contract unchanged\n");
+        if (baseline.contentHash === current.contentHash) {
+          if (!quiet) {
+            process.stderr.write("Baseline verified: contract unchanged\n");
+          }
+          return;
         }
-        return;
-      }
 
-      const report = diffSnapshots(baseline, current);
-      const { breaking, warning, safe } = report.summary;
-      const parts: string[] = [];
-      if (breaking > 0) parts.push(`${breaking} breaking`);
-      if (warning > 0) parts.push(`${warning} warning`);
-      if (safe > 0) parts.push(`${safe} safe`);
-      const summary = parts.length > 0 ? parts.join(", ") : "0";
+        const report = diffSnapshots(baseline, current);
+        const { breaking, warning, safe } = report.summary;
+        const parts: string[] = [];
+        if (breaking > 0) parts.push(`${breaking} breaking`);
+        if (warning > 0) parts.push(`${warning} warning`);
+        if (safe > 0) parts.push(`${safe} safe`);
+        const summary = parts.length > 0 ? parts.join(", ") : "0";
 
-      process.stderr.write(`Baseline mismatch: contract has changed (${summary} changes)\n`);
-      throw new CliExitError(1);
-    }),
-  );
+        process.stderr.write(`Baseline mismatch: contract has changed (${summary} changes)\n`);
+        throw new CliExitError(1);
+      }),
+    );
 
   return cmd;
 }

--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -1,0 +1,328 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createSnapshot } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { createCheckCommand } from "./check.js";
+
+/** Creates a snapshot matching the mock captureSnapshot output. */
+function makeMockSnapshot() {
+  return createSnapshot({
+    server: {
+      name: "test-server",
+      version: "1.0.0",
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+    },
+    tools: [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    capture: { transport: "stdio", source: "node", tool: "mcpdiff/0.1.0" },
+  });
+}
+
+vi.mock("./capture.js", () => ({
+  captureSnapshot: vi.fn().mockImplementation(async () => ({
+    snapshot: makeMockSnapshot(),
+    serverName: "test-server",
+    serverVersion: "1.0.0",
+  })),
+}));
+
+const TMP_DIR = resolve(import.meta.dirname, "__tmp_check_test");
+const FIXTURES_DIR = resolve(import.meta.dirname, "../../../core/src/__fixtures__");
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file path")
+    .option("--quiet", "Suppress non-essential output")
+    .option("--verbose", "Show detailed information")
+    .option("--project <path>", "Path to mcpcontracts.json");
+  program.addCommand(createCheckCommand());
+  return program;
+}
+
+/** Creates a baseline snapshot from the mock server data for testing. */
+function createMockBaseline(): string {
+  const snapshot = makeMockSnapshot();
+  const filePath = resolve(TMP_DIR, "baseline.mcpc.json");
+  writeFileSync(filePath, JSON.stringify(snapshot, null, 2), "utf-8");
+  return filePath;
+}
+
+describe("check command", () => {
+  let stdoutData: string;
+  let stderrData: string;
+  let exitCode: number | undefined;
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+  let exitSpy: MockInstance;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    stdoutData = "";
+    stderrData = "";
+    exitCode = undefined;
+    originalEnv = { ...process.env };
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutData += String(chunk);
+      return true;
+    });
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+    mkdirSync(TMP_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    process.env = originalEnv;
+    if (existsSync(TMP_DIR)) {
+      rmSync(TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("registers with all expected options", () => {
+    const program = createProgram();
+    const checkCmd = program.commands.find((c) => c.name() === "check");
+    expect(checkCmd).toBeDefined();
+
+    const optionNames = checkCmd?.options.map((o) => o.long) ?? [];
+    for (const opt of [
+      "--baseline",
+      "--fail-on",
+      "--severity",
+      "--webhook",
+      "--verify-signature",
+      "--signature-key",
+      "--watch",
+      "--watch-paths",
+      "--debounce",
+      "--clear",
+      "--command",
+      "--args",
+      "--url",
+      "--sse",
+      "--header",
+      "--config",
+      "--server",
+      "--env",
+    ]) {
+      expect(optionNames).toContain(opt);
+    }
+  });
+
+  it("exits 0 and reports no changes with a matching baseline", async () => {
+    const baselinePath = createMockBaseline();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+    ]);
+    const report = JSON.parse(stdoutData);
+    expect(report.changes).toHaveLength(0);
+    expect(report.summary.breaking).toBe(0);
+    expect(exitCode).toBeUndefined();
+    expect(stderrData).toContain("Contract unchanged");
+  });
+
+  it("exits 1 when breaking changes exceed the default threshold", async () => {
+    const baselinePath = resolve(FIXTURES_DIR, "server-v1.mcpc.json");
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "--format",
+        "json",
+        "check",
+        "--baseline",
+        baselinePath,
+        "--command",
+        "node",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it("exits 0 with matching baseline even with --fail-on safe", async () => {
+    const baselinePath = createMockBaseline();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+      "--fail-on",
+      "safe",
+    ]);
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("respects --severity for display filtering", async () => {
+    const baselinePath = resolve(FIXTURES_DIR, "server-v1.mcpc.json");
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "--format",
+        "json",
+        "check",
+        "--baseline",
+        baselinePath,
+        "--command",
+        "node",
+        "--severity",
+        "breaking",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    const report = JSON.parse(stdoutData);
+    expect(report.changes.length).toBeGreaterThan(0);
+    for (const change of report.changes) {
+      expect(change.severity).toBe("breaking");
+    }
+  });
+
+  it("uses CI-suggested format when no explicit --format", async () => {
+    const baselinePath = createMockBaseline();
+    process.env.GITHUB_ACTIONS = "true";
+    process.env.GITHUB_STEP_SUMMARY = "";
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+    ]);
+    // GitHub Actions suggests markdown format
+    expect(stdoutData).toContain("#");
+  });
+
+  it("writes to GITHUB_STEP_SUMMARY when in GitHub Actions", async () => {
+    const baselinePath = createMockBaseline();
+    const summaryPath = resolve(TMP_DIR, "step-summary.md");
+    writeFileSync(summaryPath, "", "utf-8");
+
+    process.env.GITHUB_ACTIONS = "true";
+    process.env.GITHUB_STEP_SUMMARY = summaryPath;
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+    ]);
+    const summaryContent = readFileSync(summaryPath, "utf-8");
+    expect(summaryContent.length).toBeGreaterThan(0);
+    expect(summaryContent).toContain("#");
+  });
+
+  it("defaults to contracts/baseline.mcpc.json when no baseline is given", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "check", "--command", "node"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("contracts/baseline.mcpc.json");
+  });
+
+  it("errors if no transport specified", async () => {
+    const baselinePath = createMockBaseline();
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "check", "--baseline", baselinePath]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Specify one of");
+  });
+
+  it("warns on webhook failure without affecting exit code", async () => {
+    const baselinePath = createMockBaseline();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "check",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+      "--webhook",
+      "http://localhost:1/unreachable",
+    ]);
+    expect(exitCode).toBeUndefined();
+    expect(stderrData).toContain("Warning: Webhook failed");
+  });
+
+  it("requires a key for --verify-signature", async () => {
+    const baselinePath = createMockBaseline();
+    delete process.env.MCP_SIGNATURE_KEY;
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "check",
+        "--baseline",
+        baselinePath,
+        "--command",
+        "node",
+        "--verify-signature",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("--signature-key");
+  });
+});

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -36,7 +36,7 @@ import { resolveWatchOptions } from "./watch.js";
  * @param explicitFormat - The --format value, if given.
  * @returns The resolved output format.
  */
-function resolveCheckFormat(explicitFormat: string | undefined): OutputFormat {
+export function resolveCheckFormat(explicitFormat: string | undefined): OutputFormat {
   if (explicitFormat) {
     return resolveFormat(explicitFormat);
   }
@@ -55,7 +55,7 @@ function resolveCheckFormat(explicitFormat: string | undefined): OutputFormat {
  * @param noColor - Strip ANSI colors from terminal output.
  * @returns The formatted report string.
  */
-function formatReport(report: DiffReport, format: OutputFormat, noColor: boolean): string {
+export function formatReport(report: DiffReport, format: OutputFormat, noColor: boolean): string {
   let output: string;
   if (format === "json") {
     output = formatJson(report);

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,0 +1,187 @@
+import { appendFileSync } from "node:fs";
+import type { DiffReport } from "@mcp-contracts/core";
+import {
+  createEmptyDiffReport,
+  createWebhookPayload,
+  diffSnapshots,
+  formatJson,
+  formatMarkdown,
+  formatTerminal,
+  SEVERITY_ORDER,
+} from "@mcp-contracts/core";
+import { Command } from "commander";
+import { verifyBaselineSignature } from "../baseline-signature.js";
+import { detectCIEnvironment } from "../ci-env.js";
+import { loadProjectConfig, resolveTransportOrProject } from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import {
+  CliExitError,
+  getRootOpts,
+  handleErrors,
+  type OutputFormat,
+  readSnapshotFile,
+  resolveFormat,
+  stripAnsi,
+  writeOutput,
+} from "../utils.js";
+import { runWatchLoop } from "../watch-loop.js";
+import { sendWebhook } from "../webhook.js";
+import { captureSnapshot } from "./capture.js";
+import { resolveWatchOptions } from "./watch.js";
+
+/**
+ * Resolves the output format: explicit --format wins, then the CI
+ * environment's suggestion, then TTY detection.
+ *
+ * @param explicitFormat - The --format value, if given.
+ * @returns The resolved output format.
+ */
+function resolveCheckFormat(explicitFormat: string | undefined): OutputFormat {
+  if (explicitFormat) {
+    return resolveFormat(explicitFormat);
+  }
+  const ciEnv = detectCIEnvironment();
+  if (ciEnv.isCI) {
+    return ciEnv.suggestedFormat as OutputFormat;
+  }
+  return resolveFormat(undefined);
+}
+
+/**
+ * Formats a diff report in the requested output format.
+ *
+ * @param report - The diff report to format.
+ * @param format - The output format.
+ * @param noColor - Strip ANSI colors from terminal output.
+ * @returns The formatted report string.
+ */
+function formatReport(report: DiffReport, format: OutputFormat, noColor: boolean): string {
+  let output: string;
+  if (format === "json") {
+    output = formatJson(report);
+  } else if (format === "markdown") {
+    output = formatMarkdown(report);
+  } else {
+    output = formatTerminal(report);
+  }
+  if (noColor && format === "terminal") {
+    output = stripAnsi(output);
+  }
+  return output;
+}
+
+/**
+ * Creates the `check` subcommand for the mcpdiff CLI.
+ *
+ * The one command for "does the live server still match the baseline":
+ * captures a snapshot, diffs it against the baseline, reports, and sets the
+ * exit code. Detects CI environments, optionally verifies the baseline
+ * signature, and re-runs on file changes with --watch.
+ *
+ * @returns A Commander Command instance for the check subcommand.
+ */
+export function createCheckCommand(): Command {
+  const cmd = new Command("check").description("Verify the live server still matches the baseline");
+
+  addTransportOptions(cmd);
+
+  cmd
+    .option("--baseline <path>", "Path to baseline snapshot")
+    .option("--fail-on <level>", 'Severity threshold for exit code 1 (default: "breaking")')
+    .option("--severity <level>", "Minimum severity to display", "safe")
+    .option("--webhook <url>", "POST diff results to a webhook URL")
+    .option("--verify-signature", "Require valid signature on baseline before diffing")
+    .option("--signature-key <path>", "Path to public key for signature verification")
+    .option("--watch", "Re-run the check on file changes")
+    .option("--watch-paths <paths...>", 'Paths to watch with --watch (default: ".")')
+    .option("--debounce <ms>", "Debounce interval for --watch in milliseconds (default: 500)")
+    .option("--clear", "Clear screen between --watch cycles")
+    .action(
+      handleErrors(async (options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const quiet = rootOpts["quiet"] === true;
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+
+        // Shared flags > config > defaults resolution with the watch command.
+        const { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear } =
+          resolveWatchOptions(options, project);
+
+        const baseline = readSnapshotFile(baselinePath);
+
+        if (options["verifySignature"] === true) {
+          verifyBaselineSignature(
+            baseline,
+            baselinePath,
+            options["signatureKey"] as string | undefined,
+            quiet,
+          );
+        }
+
+        const transport = resolveTransportOrProject(options, project);
+
+        if (options["watch"] === true) {
+          await runWatchLoop({
+            transport,
+            baselinePath,
+            watchPaths,
+            debounceMs,
+            minSeverity: severity,
+            failOn,
+            webhookUrl,
+            shouldClear,
+            quiet,
+          });
+          return;
+        }
+
+        const { snapshot: current } = await captureSnapshot({ transport, quiet });
+
+        // Fast path from the absorbed `baseline verify`: freshly captured
+        // snapshots hash honestly, so a matching hash means no changes and
+        // the diff engine can be skipped.
+        const unchanged = baseline.contentHash === current.contentHash;
+        const report = unchanged
+          ? createEmptyDiffReport(baseline, current)
+          : diffSnapshots(baseline, current, { minSeverity: severity });
+
+        const format = resolveCheckFormat(rootOpts["format"] as string | undefined);
+        const noColor = rootOpts["color"] === false;
+        const output = formatReport(report, format, noColor);
+        writeOutput(`${output}\n`, rootOpts["output"] as string | undefined);
+
+        if (unchanged && !quiet) {
+          process.stderr.write("Contract unchanged\n");
+        }
+
+        // GitHub Actions step summary
+        const ciEnv = detectCIEnvironment();
+        if (ciEnv.stepSummaryPath) {
+          appendFileSync(ciEnv.stepSummaryPath, `${formatMarkdown(report)}\n`);
+        }
+
+        if (webhookUrl) {
+          const payload = createWebhookPayload(report, { trigger: "ci", baselinePath });
+          const webhookResult = await sendWebhook(webhookUrl, payload);
+          if (!webhookResult.success) {
+            process.stderr.write(`Warning: Webhook failed: ${webhookResult.error}\n`);
+          }
+        }
+
+        if (unchanged) {
+          return;
+        }
+
+        // Determine exit code using the unfiltered diff
+        const fullReport = diffSnapshots(baseline, current);
+        const failThreshold = SEVERITY_ORDER[failOn];
+        const hasFailure = fullReport.changes.some(
+          (c) => SEVERITY_ORDER[c.severity] >= failThreshold,
+        );
+        if (hasFailure) {
+          throw new CliExitError(1);
+        }
+      }),
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/commands/ci.ts
+++ b/packages/cli/src/commands/ci.ts
@@ -12,10 +12,15 @@ import {
 } from "@mcp-contracts/core";
 import { Command } from "commander";
 import { detectCIEnvironment } from "../ci-env.js";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
+import {
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
 import {
   CliExitError,
+  getRootOpts,
   handleErrors,
   readSnapshotFile,
   resolveFormat,
@@ -58,8 +63,8 @@ export function createCiCommand(): Command {
   addTransportOptions(cmd);
 
   cmd
-    .requiredOption("--baseline <path>", "Path to baseline snapshot (required)")
-    .option("--fail-on <level>", "Severity threshold for exit code 1", "breaking")
+    .option("--baseline <path>", "Path to baseline snapshot")
+    .option("--fail-on <level>", 'Severity threshold for exit code 1 (default: "breaking")')
     .option("--severity <level>", "Minimum severity to display", "safe")
     .option("--webhook <url>", "POST diff results to a webhook URL")
     .option("--verify-signature", "Require valid signature on baseline before diffing")
@@ -72,32 +77,34 @@ export function createCiCommand(): Command {
         const outputPath = rootOpts["output"] as string | undefined;
         const explicitFormat = rootOpts["format"] as string | undefined;
 
-        const severity = parseSeverity(options["severity"] as string, "--severity");
-        const failOn = parseSeverity(options["failOn"] as string, "--fail-on");
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
 
-        const baseline = readSnapshotFile(options["baseline"] as string);
+        const severity = parseSeverity(options["severity"] as string, "--severity");
+        const failOn = parseSeverity(
+          (options["failOn"] as string | undefined) ?? project?.config.failOn ?? "breaking",
+          "--fail-on",
+        );
+
+        const baselinePath = resolveBaselinePath(
+          options["baseline"] as string | undefined,
+          project,
+        );
+        if (!baselinePath) {
+          throw new Error('--baseline is required (or set "baseline" in mcpcontracts.json)');
+        }
+        const baseline = readSnapshotFile(baselinePath);
 
         // Verify baseline signature if requested
         if (options["verifySignature"] === true) {
           verifyBaselineSignature(
             baseline,
-            options["baseline"] as string,
+            baselinePath,
             options["signatureKey"] as string | undefined,
             quiet,
           );
         }
 
-        const transportOpts: TransportOptions = {
-          command: options["command"] as string | undefined,
-          url: options["url"] as string | undefined,
-          config: options["config"] as string | undefined,
-          server: options["server"] as string | undefined,
-          args: options["args"] as string[] | undefined,
-          env: options["env"] as string[] | undefined,
-          sse: options["sse"] === true ? true : undefined,
-          header: options["header"] as string[] | undefined,
-        };
-        const config = resolveTransport(transportOpts);
+        const config = resolveTransportOrProject(options, project);
 
         const { snapshot: current } = await captureSnapshot({ transport: config, quiet });
 
@@ -144,7 +151,7 @@ export function createCiCommand(): Command {
         if (webhookUrl) {
           const payload = createWebhookPayload(report, {
             trigger: "ci",
-            baselinePath: options["baseline"] as string,
+            baselinePath,
           });
           const webhookResult = await sendWebhook(webhookUrl, payload);
           if (!webhookResult.success) {
@@ -166,20 +173,6 @@ export function createCiCommand(): Command {
     );
 
   return cmd;
-}
-
-/**
- * Resolves the root program options from a deeply nested subcommand.
- *
- * @param cmd - The current Command instance.
- * @returns The root program's parsed options.
- */
-function getRootOpts(cmd: Command): Record<string, unknown> {
-  let current: Command | null = cmd;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
 }
 
 /**

--- a/packages/cli/src/commands/ci.ts
+++ b/packages/cli/src/commands/ci.ts
@@ -2,9 +2,7 @@ import { appendFileSync } from "node:fs";
 import {
   createWebhookPayload,
   diffSnapshots,
-  formatJson,
   formatMarkdown,
-  formatTerminal,
   SEVERITY_ORDER,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
@@ -21,13 +19,13 @@ import {
   getRootOpts,
   handleErrors,
   parseSeverity,
+  printDeprecationNotice,
   readSnapshotFile,
-  resolveFormat,
-  stripAnsi,
   writeOutput,
 } from "../utils.js";
 import { sendWebhook } from "../webhook.js";
 import { captureSnapshot } from "./capture.js";
+import { formatReport, resolveCheckFormat } from "./check.js";
 
 /**
  * Creates the `ci` subcommand for the mcpdiff CLI.
@@ -55,6 +53,9 @@ export function createCiCommand(): Command {
       handleErrors(async (options: Record<string, unknown>) => {
         const rootOpts = getRootOpts(cmd);
         const quiet = rootOpts["quiet"] === true;
+        if (!quiet) {
+          printDeprecationNotice("mcpdiff ci", "mcpdiff check");
+        }
         const noColor = rootOpts["color"] === false;
         const outputPath = rootOpts["output"] as string | undefined;
         const explicitFormat = rootOpts["format"] as string | undefined;
@@ -93,33 +94,9 @@ export function createCiCommand(): Command {
         // Diff
         const report = diffSnapshots(baseline, current, { minSeverity: severity });
 
-        // Detect CI environment
         const ciEnv = detectCIEnvironment();
-
-        // Resolve format
-        let format: "terminal" | "json" | "markdown";
-        if (explicitFormat) {
-          format = resolveFormat(explicitFormat);
-        } else if (ciEnv.isCI) {
-          format = ciEnv.suggestedFormat as "json" | "markdown";
-        } else {
-          format = resolveFormat(undefined);
-        }
-
-        // Format report
-        let output: string;
-        if (format === "json") {
-          output = formatJson(report);
-        } else if (format === "markdown") {
-          output = formatMarkdown(report);
-        } else {
-          output = formatTerminal(report);
-        }
-
-        if (noColor && format === "terminal") {
-          output = stripAnsi(output);
-        }
-
+        const format = resolveCheckFormat(explicitFormat);
+        const output = formatReport(report, format, noColor);
         writeOutput(`${output}\n`, outputPath);
 
         // GitHub Actions step summary

--- a/packages/cli/src/commands/ci.ts
+++ b/packages/cli/src/commands/ci.ts
@@ -1,16 +1,14 @@
-import { appendFileSync, readFileSync } from "node:fs";
-import type { MCPContractSnapshot, Severity } from "@mcp-contracts/core";
+import { appendFileSync } from "node:fs";
 import {
   createWebhookPayload,
   diffSnapshots,
   formatJson,
   formatMarkdown,
   formatTerminal,
-  parseSignatureFile,
   SEVERITY_ORDER,
-  verifySignature,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
+import { verifyBaselineSignature } from "../baseline-signature.js";
 import { detectCIEnvironment } from "../ci-env.js";
 import {
   loadProjectConfig,
@@ -22,6 +20,7 @@ import {
   CliExitError,
   getRootOpts,
   handleErrors,
+  parseSeverity,
   readSnapshotFile,
   resolveFormat,
   stripAnsi,
@@ -29,23 +28,6 @@ import {
 } from "../utils.js";
 import { sendWebhook } from "../webhook.js";
 import { captureSnapshot } from "./capture.js";
-import { deriveSignaturePath } from "./sign.js";
-
-const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
-
-/**
- * Validates a severity level string.
- *
- * @param value - The string to validate.
- * @param label - Label for the option (used in error messages).
- * @returns The validated Severity value.
- */
-function parseSeverity(value: string, label: string): Severity {
-  if (!VALID_SEVERITIES.has(value)) {
-    throw new Error(`Invalid ${label} value "${value}". Must be one of: safe, warning, breaking`);
-  }
-  return value as Severity;
-}
 
 /**
  * Creates the `ci` subcommand for the mcpdiff CLI.
@@ -173,80 +155,4 @@ export function createCiCommand(): Command {
     );
 
   return cmd;
-}
-
-/**
- * Verifies the baseline snapshot's signature before diffing.
- *
- * @param baseline - The parsed baseline snapshot.
- * @param baselinePath - File path to the baseline (used to derive sig path).
- * @param signatureKeyOption - The --signature-key option value, if provided.
- * @param quiet - Whether to suppress non-essential output.
- */
-function verifyBaselineSignature(
-  baseline: MCPContractSnapshot,
-  baselinePath: string,
-  signatureKeyOption: string | undefined,
-  quiet: boolean,
-): void {
-  const keyPem = resolveSignatureKey(signatureKeyOption);
-  const sigPath = deriveSignaturePath(baselinePath);
-
-  let sigJson: string;
-  try {
-    sigJson = readFileSync(sigPath, "utf-8");
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to read baseline signature file "${sigPath}": ${message}`);
-  }
-
-  const sig = parseSignatureFile(sigJson);
-  const result = verifySignature(baseline, sig, keyPem);
-
-  if (!result.valid) {
-    process.stderr.write(`Baseline signature verification failed: ${result.error}\n`);
-    throw new CliExitError(2);
-  }
-
-  if (!quiet) {
-    process.stderr.write("Baseline signature verified\n");
-  }
-}
-
-/**
- * Resolves the public key PEM for signature verification.
- *
- * Checks the `--signature-key` option first, then the `MCP_SIGNATURE_KEY`
- * environment variable. The env var can contain PEM content directly
- * (starts with "-----BEGIN") or a file path.
- *
- * @param optionValue - The --signature-key option value, if provided.
- * @returns The PEM string for the public key.
- */
-function resolveSignatureKey(optionValue: string | undefined): string {
-  if (optionValue) {
-    try {
-      return readFileSync(optionValue, "utf-8");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to read signature key file "${optionValue}": ${message}`);
-    }
-  }
-
-  const envValue = process.env["MCP_SIGNATURE_KEY"];
-  if (envValue) {
-    if (envValue.startsWith("-----BEGIN")) {
-      return envValue;
-    }
-    try {
-      return readFileSync(envValue, "utf-8");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to read key from MCP_SIGNATURE_KEY path "${envValue}": ${message}`);
-    }
-  }
-
-  throw new Error(
-    "--verify-signature requires --signature-key <path> or MCP_SIGNATURE_KEY environment variable",
-  );
 }

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -18,6 +18,7 @@ import { addTransportOptions } from "../transport.js";
 import {
   CliExitError,
   handleErrors,
+  parseSeverity,
   readSnapshotFile,
   resolveFormat,
   stripAnsi,
@@ -26,22 +27,6 @@ import {
 import { sendWebhook } from "../webhook.js";
 import { captureSnapshot } from "./capture.js";
 import { executeCompositionDiff } from "./diff-composition.js";
-
-const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
-
-/**
- * Validates that a string is a valid Severity level.
- *
- * @param value - The string to validate.
- * @param label - Label for the option (used in error messages).
- * @returns The validated Severity value.
- */
-function parseSeverity(value: string, label: string): Severity {
-  if (!VALID_SEVERITIES.has(value)) {
-    throw new Error(`Invalid ${label} value "${value}". Must be one of: safe, warning, breaking`);
-  }
-  return value as Severity;
-}
 
 /**
  * Resolves the "after" snapshot, either from file or by capturing from a live server.

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -8,8 +8,13 @@ import {
   SEVERITY_ORDER,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
+import type { LoadedProjectConfig } from "../project-config.js";
+import {
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
 import {
   CliExitError,
   handleErrors,
@@ -44,6 +49,7 @@ function parseSeverity(value: string, label: string): Severity {
  * @param afterPath - Path to snapshot file (may be undefined in live mode).
  * @param live - Whether live mode is enabled.
  * @param options - CLI options containing transport settings.
+ * @param project - The loaded project config, if any (live mode only).
  * @param quiet - Suppress non-essential output.
  * @returns The "after" snapshot.
  */
@@ -51,6 +57,7 @@ async function resolveAfterSnapshot(
   afterPath: string | undefined,
   live: boolean,
   options: Record<string, unknown>,
+  project: LoadedProjectConfig | null,
   quiet: boolean,
 ): Promise<MCPContractSnapshot> {
   if (!live) {
@@ -60,18 +67,7 @@ async function resolveAfterSnapshot(
     return readSnapshotFile(afterPath);
   }
 
-  const transportOpts: TransportOptions = {
-    command: options["command"] as string | undefined,
-    url: options["url"] as string | undefined,
-    config: options["config"] as string | undefined,
-    server: options["server"] as string | undefined,
-    args: options["args"] as string[] | undefined,
-    env: options["env"] as string[] | undefined,
-    sse: options["sse"] === true ? true : undefined,
-    header: options["header"] as string[] | undefined,
-  };
-
-  const config = resolveTransport(transportOpts);
+  const config = resolveTransportOrProject(options, project);
   const { snapshot } = await captureSnapshot({ transport: config, quiet });
   return snapshot;
 }
@@ -81,6 +77,7 @@ interface FileDiffOptions {
   beforePath: string;
   afterPath: string | undefined;
   live: boolean;
+  project: LoadedProjectConfig | null;
   options: Record<string, unknown>;
   severity: Severity;
   failOn: Severity;
@@ -101,6 +98,7 @@ async function runFileDiff(params: FileDiffOptions): Promise<void> {
     params.afterPath,
     params.live,
     params.options,
+    params.project,
     params.quiet,
   );
 
@@ -206,16 +204,27 @@ export function createDiffCommand(): Command {
           return;
         }
 
-        if (!beforePath) {
+        // In live mode the project config can supply both the baseline
+        // ("before") and the server transport; file-to-file diffs ignore it.
+        const project = live
+          ? loadProjectConfig(parentOpts["project"] as string | undefined)
+          : null;
+        const resolvedBefore =
+          beforePath ?? (live ? resolveBaselinePath(undefined, project) : undefined);
+
+        if (!resolvedBefore) {
           throw new Error(
-            "Two snapshot file paths are required (or use --baseline for a composition diff)",
+            live
+              ? 'A baseline snapshot path is required (or set "baseline" in mcpcontracts.json)'
+              : "Two snapshot file paths are required (or use --baseline for a composition diff)",
           );
         }
 
         await runFileDiff({
-          beforePath,
+          beforePath: resolvedBefore,
           afterPath,
           live,
+          project,
           options,
           severity,
           failOn,

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -19,6 +19,7 @@ import {
   CliExitError,
   handleErrors,
   parseSeverity,
+  printDeprecationNotice,
   readSnapshotFile,
   resolveFormat,
   stripAnsi,
@@ -128,6 +129,44 @@ async function runFileDiff(params: FileDiffOptions): Promise<void> {
 }
 
 /**
+ * Validates composition-diff arguments and delegates to executeCompositionDiff.
+ *
+ * @param baselineDir - The --baseline directory option value.
+ * @param beforePath - The first positional argument, which must be absent.
+ * @param options - The parsed command options.
+ * @param parentOpts - The root program's parsed options.
+ * @param severity - Minimum severity to display.
+ * @param failOn - Exit code 1 threshold.
+ */
+async function runCompositionDiff(
+  baselineDir: string,
+  beforePath: string | undefined,
+  options: Record<string, unknown>,
+  parentOpts: Record<string, unknown>,
+  severity: Severity,
+  failOn: Severity,
+): Promise<void> {
+  const configPath = options["config"] as string | undefined;
+  if (!configPath) {
+    throw new Error("--baseline requires --config");
+  }
+  if (beforePath) {
+    throw new Error("--baseline cannot be combined with snapshot file arguments");
+  }
+
+  await executeCompositionDiff({
+    configPath,
+    baselineDir,
+    minSeverity: severity,
+    failOn,
+    quiet: parentOpts["quiet"] === true,
+    format: resolveFormat(parentOpts["format"] as string | undefined),
+    noColor: parentOpts["color"] === false,
+    outputPath: parentOpts["output"] as string | undefined,
+  });
+}
+
+/**
  * Creates the `diff` subcommand for the mcpdiff CLI.
  *
  * Supports two modes:
@@ -162,30 +201,15 @@ export function createDiffCommand(): Command {
         const severity = parseSeverity(options["severity"] as string, "--severity");
         const failOn = parseSeverity(options["failOn"] as string, "--fail-on");
         const live = options["live"] === true;
-
         const parentOpts = cmd.parent?.opts() ?? {};
         const quiet = parentOpts["quiet"] === true;
+        if (live && !quiet) {
+          printDeprecationNotice("mcpdiff diff --live", "mcpdiff check");
+        }
 
         const baselineDir = options["baseline"] as string | undefined;
         if (baselineDir) {
-          const configPath = options["config"] as string | undefined;
-          if (!configPath) {
-            throw new Error("--baseline requires --config");
-          }
-          if (beforePath) {
-            throw new Error("--baseline cannot be combined with snapshot file arguments");
-          }
-
-          await executeCompositionDiff({
-            configPath,
-            baselineDir,
-            minSeverity: severity,
-            failOn,
-            quiet,
-            format: resolveFormat(parentOpts["format"] as string | undefined),
-            noColor: parentOpts["color"] === false,
-            outputPath: parentOpts["output"] as string | undefined,
-          });
+          await runCompositionDiff(baselineDir, beforePath, options, parentOpts, severity, failOn);
           return;
         }
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,0 +1,217 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createSnapshot } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { buildServerFromFlags, createInitCommand } from "./init.js";
+
+/** Creates a snapshot matching the mock captureSnapshot output. */
+function makeMockSnapshot() {
+  return createSnapshot({
+    server: {
+      name: "test-server",
+      version: "1.0.0",
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+    },
+    tools: [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    capture: { transport: "stdio", source: "node", tool: "mcpdiff/0.1.0" },
+  });
+}
+
+vi.mock("./capture.js", () => ({
+  captureSnapshot: vi.fn().mockImplementation(async () => ({
+    snapshot: makeMockSnapshot(),
+    serverName: "test-server",
+    serverVersion: "1.0.0",
+  })),
+}));
+
+import { captureSnapshot } from "./capture.js";
+
+const TMP_DIR = resolve(import.meta.dirname, "__tmp_init_test");
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file path")
+    .option("--quiet", "Suppress non-essential output")
+    .option("--verbose", "Show detailed information")
+    .option("--project <path>", "Path to mcpcontracts.json");
+  program.addCommand(createInitCommand());
+  return program;
+}
+
+describe("buildServerFromFlags", () => {
+  it("builds a command block with args and env", () => {
+    expect(buildServerFromFlags({ command: "node", args: ["server.js"], env: ["A=b"] })).toEqual({
+      command: "node",
+      args: ["server.js"],
+      env: { A: "b" },
+    });
+  });
+
+  it("builds a url block with sse and headers", () => {
+    expect(
+      buildServerFromFlags({ url: "http://localhost:3000", sse: true, header: ["X: y"] }),
+    ).toEqual({ url: "http://localhost:3000", sse: true, headers: { X: "y" } });
+  });
+
+  it("builds a config reference block", () => {
+    expect(buildServerFromFlags({ config: "./mcp.json", server: "alpha" })).toEqual({
+      config: "./mcp.json",
+      name: "alpha",
+    });
+  });
+
+  it("rejects zero or multiple transports", () => {
+    expect(() => buildServerFromFlags({ args: ["x"] })).toThrow(/Specify one of/);
+    expect(() => buildServerFromFlags({ command: "node", url: "http://x" })).toThrow(
+      /Specify only one of/,
+    );
+  });
+});
+
+describe("init command", () => {
+  let stderrData: string;
+  let exitCode: number | undefined;
+  let stderrSpy: MockInstance;
+  let exitSpy: MockInstance;
+  let stdoutSpy: MockInstance;
+  let cwdSpy: MockInstance;
+
+  beforeEach(() => {
+    stderrData = "";
+    exitCode = undefined;
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+    mkdirSync(TMP_DIR, { recursive: true });
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(TMP_DIR);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    cwdSpy.mockRestore();
+    if (existsSync(TMP_DIR)) {
+      rmSync(TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("writes config and baseline, prints next steps with CI snippet", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "init", "--command", "node", "--args", "srv.js"]);
+
+    const config = JSON.parse(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8"));
+    expect(config).toEqual({
+      server: { command: "node", args: ["srv.js"] },
+      baseline: "contracts/baseline.mcpc.json",
+      failOn: "breaking",
+    });
+
+    const baseline = JSON.parse(
+      readFileSync(resolve(TMP_DIR, "contracts/baseline.mcpc.json"), "utf-8"),
+    );
+    expect(baseline.server.name).toBe("test-server");
+    expect(baseline.contentHash).toMatch(/^sha256:/);
+
+    expect(stderrData).toContain("Wrote mcpcontracts.json");
+    expect(stderrData).toContain("1 tools");
+    expect(stderrData).toContain("mcpdiff check");
+    expect(stderrData).toContain("mcp-contract.yml");
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("writes a url server block", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "init", "--url", "http://localhost:3000/mcp"]);
+    const config = JSON.parse(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8"));
+    expect(config.server).toEqual({ url: "http://localhost:3000/mcp" });
+  });
+
+  it("writes a config reference block", async () => {
+    writeFileSync(
+      resolve(TMP_DIR, "mcp.json"),
+      JSON.stringify({ mcpServers: { alpha: { command: "node", args: ["a.js"] } } }),
+      "utf-8",
+    );
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "init",
+      "--config",
+      "./mcp.json",
+      "--server",
+      "alpha",
+    ]);
+    const config = JSON.parse(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8"));
+    expect(config.server).toEqual({ config: "./mcp.json", name: "alpha" });
+  });
+
+  it("refuses to overwrite an existing config without --force", async () => {
+    writeFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "{}", "utf-8");
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "init", "--command", "node"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("--force");
+    expect(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8")).toBe("{}");
+  });
+
+  it("overwrites with --force", async () => {
+    writeFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "{}", "utf-8");
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "init", "--command", "node", "--force"]);
+    const config = JSON.parse(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8"));
+    expect(config.server).toEqual({ command: "node" });
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("exits 2 without flags when stdin is not a TTY", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "init"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("--command");
+    expect(existsSync(resolve(TMP_DIR, "mcpcontracts.json"))).toBe(false);
+  });
+
+  it("writes nothing when the capture fails", async () => {
+    vi.mocked(captureSnapshot).mockRejectedValueOnce(new Error("connection refused"));
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "init", "--command", "node"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(existsSync(resolve(TMP_DIR, "mcpcontracts.json"))).toBe(false);
+    expect(existsSync(resolve(TMP_DIR, "contracts"))).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,196 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { createInterface } from "node:readline/promises";
+import type { MCPContractSnapshot, ProjectConfig, ProjectServer } from "@mcp-contracts/core";
+import { PROJECT_CONFIG_FILENAME, parseProjectConfig } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { listConfigServers } from "../mcp-config.js";
+import { DEFAULT_BASELINE_PATH, resolveProjectTransport } from "../project-config.js";
+import type { TransportOptions } from "../transport.js";
+import {
+  addTransportOptions,
+  extractTransportOptions,
+  hasTransportFlags,
+  parseHeaders,
+} from "../transport.js";
+import { getRootOpts, handleErrors, parseEnvPairs } from "../utils.js";
+import { captureSnapshot } from "./capture.js";
+
+/** CI workflow snippet printed as part of the next steps. */
+const CI_SNIPPET = `# .github/workflows/mcp-contract.yml
+name: MCP Contract Check
+on: [pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install -g @mcp-contracts/cli
+      - run: mcpdiff check
+`;
+
+/**
+ * Builds the config file's server block from explicit transport flags.
+ *
+ * @param flags - The extracted transport options.
+ * @returns The server block to write into mcpcontracts.json.
+ */
+export function buildServerFromFlags(flags: TransportOptions): ProjectServer {
+  const transports = [flags.command, flags.url, flags.config].filter((v) => v !== undefined);
+  if (transports.length === 0) {
+    throw new Error("Specify one of: --command, --url, or --config");
+  }
+  if (transports.length > 1) {
+    throw new Error("Specify only one of: --command, --url, or --config");
+  }
+
+  if (flags.config !== undefined) {
+    return {
+      config: flags.config,
+      ...(flags.server !== undefined && { name: flags.server }),
+    };
+  }
+  if (flags.url !== undefined) {
+    return {
+      url: flags.url,
+      ...(flags.sse === true && { sse: true }),
+      ...(flags.header !== undefined && { headers: parseHeaders(flags.header) }),
+    };
+  }
+  return {
+    command: flags.command as string,
+    ...(flags.args !== undefined && { args: flags.args }),
+    ...(flags.env !== undefined && { env: parseEnvPairs(flags.env) }),
+  };
+}
+
+/**
+ * Interactively asks for the server, offering mcp.json entries when present.
+ *
+ * @param cwd - The directory being initialized.
+ * @returns The server block to write into mcpcontracts.json.
+ */
+async function promptForServer(cwd: string): Promise<ProjectServer> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const mcpJsonPath = ["mcp.json", ".mcp.json"].map((f) => join(cwd, f)).find(existsSync);
+    if (mcpJsonPath) {
+      const fileName = basename(mcpJsonPath);
+      const servers = listConfigServers(mcpJsonPath);
+      process.stderr.write(`Found ${fileName} with ${servers.length} server(s):\n`);
+      servers.forEach((s, i) => {
+        process.stderr.write(`  ${i + 1}. ${s.name}\n`);
+      });
+      const answer = (
+        await rl.question(`Use which server? [1-${servers.length}, or "m" to enter manually]: `)
+      ).trim();
+      if (answer.toLowerCase() !== "m") {
+        const index = Number.parseInt(answer, 10);
+        const chosen = servers[index - 1];
+        if (!Number.isInteger(index) || !chosen) {
+          throw new Error(`Invalid selection "${answer}"`);
+        }
+        return { config: `./${fileName}`, name: chosen.name };
+      }
+    }
+
+    const input = (await rl.question('Server command (e.g. "node dist/index.js") or URL: ')).trim();
+    if (!input) {
+      throw new Error("No server specified");
+    }
+    if (/^https?:\/\//.test(input)) {
+      return { url: input };
+    }
+    const [command, ...args] = input.split(/\s+/);
+    return args.length > 0 ? { command: command as string, args } : { command: command as string };
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Prints the post-init summary and next steps, including the CI snippet.
+ *
+ * @param snapshot - The captured baseline snapshot.
+ */
+function printNextSteps(snapshot: MCPContractSnapshot): void {
+  const tools = Object.keys(snapshot.tools).length;
+  const resources = Object.keys(snapshot.resources).length;
+  const prompts = Object.keys(snapshot.prompts).length;
+  const parts = [`${tools} tools`];
+  if (resources > 0) parts.push(`${resources} resources`);
+  if (prompts > 0) parts.push(`${prompts} prompts`);
+
+  process.stderr.write(
+    `✓ Wrote ${PROJECT_CONFIG_FILENAME}\n` +
+      `✓ Wrote ${DEFAULT_BASELINE_PATH} (${parts.join(", ")})\n` +
+      "\nNext steps:\n" +
+      `  1. Commit ${PROJECT_CONFIG_FILENAME} and ${DEFAULT_BASELINE_PATH}\n` +
+      "  2. Run `mcpdiff check` to verify the server against the baseline\n" +
+      "  3. Add contract checking to CI:\n\n" +
+      `${CI_SNIPPET}`,
+  );
+}
+
+/**
+ * Creates the `init` subcommand for the mcpdiff CLI.
+ *
+ * One-command onboarding: writes mcpcontracts.json with the chosen server,
+ * captures the initial baseline, and prints next steps. Fully scriptable via
+ * transport flags; prompts interactively on a TTY when no flags are given.
+ *
+ * @returns A Commander Command instance for the init subcommand.
+ */
+export function createInitCommand(): Command {
+  const cmd = new Command("init").description(
+    "Set up contract checking: write mcpcontracts.json and capture the baseline",
+  );
+
+  addTransportOptions(cmd);
+
+  cmd.option("--force", "Overwrite an existing mcpcontracts.json").action(
+    handleErrors(async (options: Record<string, unknown>) => {
+      const rootOpts = getRootOpts(cmd);
+      const quiet = rootOpts["quiet"] === true;
+      const cwd = process.cwd();
+      const configPath = join(cwd, PROJECT_CONFIG_FILENAME);
+
+      if (existsSync(configPath) && options["force"] !== true) {
+        throw new Error(
+          `"${PROJECT_CONFIG_FILENAME}" already exists in this directory (use --force to overwrite)`,
+        );
+      }
+
+      const flags = extractTransportOptions(options);
+      let server: ProjectServer;
+      if (hasTransportFlags(flags)) {
+        server = buildServerFromFlags(flags);
+      } else if (process.stdin.isTTY === true) {
+        server = await promptForServer(cwd);
+      } else {
+        throw new Error(
+          "No server specified. Pass --command, --url, or --config (interactive prompts require a TTY)",
+        );
+      }
+
+      const config: ProjectConfig = parseProjectConfig({
+        server,
+        baseline: DEFAULT_BASELINE_PATH,
+        failOn: "breaking",
+      });
+
+      // Capture first: nothing is written if the server is unreachable.
+      const transport = resolveProjectTransport({ path: configPath, dir: cwd, config });
+      const { snapshot } = await captureSnapshot({ transport, quiet });
+
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+      const baselinePath = join(cwd, DEFAULT_BASELINE_PATH);
+      mkdirSync(dirname(baselinePath), { recursive: true });
+      writeFileSync(baselinePath, `${JSON.stringify(snapshot, null, 2)}\n`, "utf-8");
+
+      printNextSteps(snapshot);
+    }),
+  );
+
+  return cmd;
+}

--- a/packages/cli/src/commands/mcp-client.ts
+++ b/packages/cli/src/commands/mcp-client.ts
@@ -15,6 +15,8 @@ export interface ResolvedTransport {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
+  /** Working directory for the spawned stdio server (defaults to the CWD). */
+  cwd?: string;
   url?: string;
   headers?: Record<string, string>;
 }
@@ -52,6 +54,7 @@ export async function connectToServer(config: ResolvedTransport): Promise<Connec
       command: config.command,
       args: config.args,
       env: { ...getDefaultEnvironment(), ...config.env },
+      cwd: config.cwd,
     });
   } else if (config.transport === "sse") {
     if (!config.url) {

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -2,9 +2,9 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Command } from "commander";
 import { listConfigServers } from "../mcp-config.js";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
-import { handleErrors, writeOutput } from "../utils.js";
+import { loadProjectConfig, resolveTransportOrProject } from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import { getRootOpts, handleErrors, writeOutput } from "../utils.js";
 import { captureSnapshot } from "./capture.js";
 import { captureAllServers } from "./capture-all.js";
 
@@ -63,9 +63,9 @@ export function createSnapshotCommand(): Command {
 
   cmd.action(
     handleErrors(async (options: Record<string, unknown>) => {
-      const parentOpts = cmd.parent?.opts() ?? {};
-      const outputPath = parentOpts["output"] as string | undefined;
-      const quiet = parentOpts["quiet"] === true;
+      const rootOpts = getRootOpts(cmd);
+      const outputPath = rootOpts["output"] as string | undefined;
+      const quiet = rootOpts["quiet"] === true;
 
       if (options["all"] === true) {
         const configPath = options["config"] as string | undefined;
@@ -76,17 +76,8 @@ export function createSnapshotCommand(): Command {
         return;
       }
 
-      const transportOpts: TransportOptions = {
-        command: options["command"] as string | undefined,
-        url: options["url"] as string | undefined,
-        config: options["config"] as string | undefined,
-        server: options["server"] as string | undefined,
-        args: options["args"] as string[] | undefined,
-        env: options["env"] as string[] | undefined,
-        sse: options["sse"] === true ? true : undefined,
-        header: options["header"] as string[] | undefined,
-      };
-      const config = resolveTransport(transportOpts);
+      const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+      const config = resolveTransportOrProject(options, project);
 
       const { snapshot } = await captureSnapshot({ transport: config, quiet });
 

--- a/packages/cli/src/commands/test.test.ts
+++ b/packages/cli/src/commands/test.test.ts
@@ -1,0 +1,253 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createSnapshot } from "@mcp-contracts/core";
+import type { TestReport } from "@mcp-contracts/test";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { createTestCommand } from "./test.js";
+
+vi.mock("@mcp-contracts/test", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcp-contracts/test")>();
+  return { ...actual, runContractTests: vi.fn() };
+});
+
+import { runContractTests } from "@mcp-contracts/test";
+
+const TMP_DIR = resolve(import.meta.dirname, "__tmp_test_cmd_test");
+
+function makeReport(overrides?: Partial<TestReport["summary"]>): TestReport {
+  return {
+    meta: {
+      contractPath: "contract.mcpc.json",
+      serverName: "test-server",
+      serverVersion: "1.0.0",
+      runAt: new Date().toISOString(),
+      tool: "mcp-test",
+    },
+    summary: {
+      total: 3,
+      passed: 3,
+      failed: 0,
+      skipped: 0,
+      errors: 0,
+      durationMs: 12,
+      ...overrides,
+    },
+    results: [],
+  };
+}
+
+function writeContract(): string {
+  const snapshot = createSnapshot({
+    server: {
+      name: "test-server",
+      version: "1.0.0",
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+    },
+    tools: [
+      { name: "test_tool", description: "A tool", inputSchema: { type: "object", properties: {} } },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    capture: { transport: "stdio", source: "node", tool: "mcpdiff/0.1.0" },
+  });
+  const path = resolve(TMP_DIR, "contract.mcpc.json");
+  writeFileSync(path, JSON.stringify(snapshot, null, 2), "utf-8");
+  return path;
+}
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file path")
+    .option("--quiet", "Suppress non-essential output")
+    .option("--verbose", "Show detailed information")
+    .option("--project <path>", "Path to mcpcontracts.json");
+  program.addCommand(createTestCommand());
+  return program;
+}
+
+describe("test command", () => {
+  let stdoutData: string;
+  let stderrData: string;
+  let exitCode: number | undefined;
+  let spies: MockInstance[];
+
+  beforeEach(() => {
+    stdoutData = "";
+    stderrData = "";
+    exitCode = undefined;
+    spies = [
+      vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+        stdoutData += String(chunk);
+        return true;
+      }),
+      vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+        stderrData += String(chunk);
+        return true;
+      }),
+      vi.spyOn(process, "exit").mockImplementation((code) => {
+        exitCode = code as number;
+        throw new Error(`process.exit(${code})`);
+      }),
+    ];
+    mkdirSync(TMP_DIR, { recursive: true });
+    vi.mocked(runContractTests).mockClear();
+    vi.mocked(runContractTests).mockResolvedValue(makeReport());
+  });
+
+  afterEach(() => {
+    for (const spy of spies) spy.mockRestore();
+    if (existsSync(TMP_DIR)) {
+      rmSync(TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("registers with the mcp-test run flag surface plus transport options", () => {
+    const program = createProgram();
+    const testCmd = program.commands.find((c) => c.name() === "test");
+    const optionNames = testCmd?.options.map((o) => o.long) ?? [];
+    for (const opt of [
+      "--no-conformance",
+      "--no-boundary",
+      "--allow-extra-tools",
+      "--ignore-descriptions",
+      "--skip-tools",
+      "--timeout",
+      "--command",
+      "--args",
+      "--url",
+      "--sse",
+      "--header",
+      "--config",
+      "--server",
+      "--env",
+    ]) {
+      expect(optionNames).toContain(opt);
+    }
+  });
+
+  it("runs the suite and exits 0 when everything passes", async () => {
+    const contractPath = writeContract();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "test",
+      contractPath,
+      "--command",
+      "node",
+      "--args",
+      "srv.js",
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    const report = JSON.parse(stdoutData);
+    expect(report.summary.passed).toBe(3);
+
+    const runOptions = vi.mocked(runContractTests).mock.calls[0]?.[0];
+    expect(runOptions?.server).toMatchObject({
+      transport: "stdio",
+      command: "node",
+      args: ["srv.js"],
+    });
+    expect(runOptions?.contractPath).toBe(contractPath);
+    expect(runOptions?.conformance).toEqual({
+      allowExtraTools: false,
+      ignoreDescriptions: false,
+      skipTools: undefined,
+    });
+    expect(runOptions?.boundary).toEqual({ skipTools: undefined });
+    expect(runOptions?.timeoutMs).toBe(120000);
+  });
+
+  it("exits 1 on failures", async () => {
+    vi.mocked(runContractTests).mockResolvedValue(makeReport({ failed: 1, passed: 2 }));
+    const contractPath = writeContract();
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "--format",
+        "json",
+        "test",
+        contractPath,
+        "--command",
+        "node",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it("passes through --no-conformance, --allow-extra-tools, and --skip-tools", async () => {
+    const contractPath = writeContract();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "test",
+      contractPath,
+      "--command",
+      "node",
+      "--no-conformance",
+      "--skip-tools",
+      "alpha",
+      "beta",
+      "--timeout",
+      "5000",
+    ]);
+    const runOptions = vi.mocked(runContractTests).mock.calls[0]?.[0];
+    expect(runOptions?.conformance).toBe(false);
+    expect(runOptions?.boundary).toEqual({ skipTools: ["alpha", "beta"] });
+    expect(runOptions?.timeoutMs).toBe(5000);
+  });
+
+  it("resolves contract and server from the project config with no arguments", async () => {
+    writeContract();
+    writeFileSync(
+      resolve(TMP_DIR, "mcpcontracts.json"),
+      JSON.stringify({
+        server: { command: "node", args: ["srv.js"] },
+        baseline: "contract.mcpc.json",
+      }),
+      "utf-8",
+    );
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "--project",
+      resolve(TMP_DIR, "mcpcontracts.json"),
+      "test",
+    ]);
+    expect(exitCode).toBeUndefined();
+    const runOptions = vi.mocked(runContractTests).mock.calls[0]?.[0];
+    expect(runOptions?.contractPath).toBe(resolve(TMP_DIR, "contract.mcpc.json"));
+    expect(runOptions?.server).toMatchObject({ transport: "stdio", command: "node" });
+  });
+
+  it("errors with exit 2 when no transport is available", async () => {
+    const contractPath = writeContract();
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "test", contractPath]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Specify one of");
+  });
+});

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,0 +1,128 @@
+import type { TestReport, TestRunOptions, TestServerConfig } from "@mcp-contracts/test";
+import {
+  formatTestJson,
+  formatTestMarkdown,
+  formatTestTerminal,
+  runContractTests,
+} from "@mcp-contracts/test";
+import { Command } from "commander";
+import {
+  DEFAULT_BASELINE_PATH,
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import {
+  CliExitError,
+  getRootOpts,
+  handleErrors,
+  type OutputFormat,
+  readSnapshotFile,
+  resolveFormat,
+  writeOutput,
+} from "../utils.js";
+import type { ResolvedTransport } from "./mcp-client.js";
+
+/**
+ * Maps a resolved transport to the test runner's server config.
+ *
+ * @param transport - The resolved transport from flags or project config.
+ * @returns The equivalent TestServerConfig.
+ */
+function toTestServerConfig(transport: ResolvedTransport): TestServerConfig {
+  return {
+    transport: transport.transport,
+    command: transport.command,
+    args: transport.args,
+    env: transport.env,
+    url: transport.url,
+    headers: transport.headers,
+    timeoutMs: 30_000,
+  };
+}
+
+/**
+ * Formats a test report in the requested output format.
+ *
+ * @param report - The test report to format.
+ * @param format - The output format.
+ * @returns The formatted report string.
+ */
+function formatTestReport(report: TestReport, format: OutputFormat): string {
+  if (format === "json") {
+    return formatTestJson(report);
+  }
+  if (format === "markdown") {
+    return formatTestMarkdown(report);
+  }
+  return formatTestTerminal(report);
+}
+
+/**
+ * Creates the `test` subcommand for the mcpdiff CLI.
+ *
+ * Runs the contract test suite (schema conformance + boundary inputs) from
+ * @mcp-contracts/test against a live server. With an mcpcontracts.json
+ * present, `mcpdiff test` with no arguments tests the configured baseline
+ * against the configured server.
+ *
+ * @returns A Commander Command instance for the test subcommand.
+ */
+export function createTestCommand(): Command {
+  const cmd = new Command("test")
+    .description("Run contract conformance and boundary tests against a live server")
+    .argument("[contract]", `Path to the contract file (default: "${DEFAULT_BASELINE_PATH}")`);
+
+  addTransportOptions(cmd);
+
+  cmd
+    .option("--no-conformance", "Skip schema conformance tests")
+    .option("--no-boundary", "Skip boundary input tests")
+    .option("--allow-extra-tools", "Allow tools not in the contract")
+    .option("--ignore-descriptions", "Ignore description differences")
+    .option("--skip-tools <names...>", "Skip specific tools")
+    .option("--timeout <ms>", "Global timeout in ms", "120000")
+    .action(
+      handleErrors(async (contractArg: string | undefined, options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+
+        const contractPath =
+          contractArg ?? resolveBaselinePath(undefined, project) ?? DEFAULT_BASELINE_PATH;
+        const contract = readSnapshotFile(contractPath);
+
+        const transport = resolveTransportOrProject(options, project);
+        const skipTools = options["skipTools"] as string[] | undefined;
+
+        const runOptions: TestRunOptions = {
+          contract,
+          contractPath,
+          server: toTestServerConfig(transport),
+          conformance:
+            options["conformance"] === false
+              ? false
+              : {
+                  allowExtraTools: options["allowExtraTools"] === true,
+                  ignoreDescriptions: options["ignoreDescriptions"] === true,
+                  skipTools,
+                },
+          boundary: options["boundary"] === false ? false : { skipTools },
+          timeoutMs: Number(options["timeout"]),
+        };
+
+        const report = await runContractTests(runOptions);
+
+        const format = resolveFormat(rootOpts["format"] as string | undefined);
+        const output = formatTestReport(report, format);
+        writeOutput(`${output}\n`, rootOpts["output"] as string | undefined);
+
+        // Exit codes: 0 = all pass, 1 = failures, 2 = tool error
+        if (report.summary.failed > 0 || report.summary.errors > 0) {
+          throw new CliExitError(1);
+        }
+      }),
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,0 +1,183 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createSnapshot } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { createUpdateCommand } from "./update.js";
+
+/** Creates a snapshot matching the mock captureSnapshot output. */
+function makeMockSnapshot() {
+  return createSnapshot({
+    server: {
+      name: "test-server",
+      version: "1.0.0",
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+    },
+    tools: [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    capture: { transport: "stdio", source: "node", tool: "mcpdiff/0.1.0" },
+  });
+}
+
+vi.mock("./capture.js", () => ({
+  captureSnapshot: vi.fn().mockImplementation(async () => ({
+    snapshot: makeMockSnapshot(),
+    serverName: "test-server",
+    serverVersion: "1.0.0",
+  })),
+}));
+
+const TMP_DIR = resolve(import.meta.dirname, "__tmp_update_test");
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file path")
+    .option("--quiet", "Suppress non-essential output")
+    .option("--verbose", "Show detailed information")
+    .option("--project <path>", "Path to mcpcontracts.json");
+  program.addCommand(createUpdateCommand());
+  return program;
+}
+
+describe("update command", () => {
+  let stderrData: string;
+  let exitCode: number | undefined;
+  let stderrSpy: MockInstance;
+  let exitSpy: MockInstance;
+  let stdoutSpy: MockInstance;
+
+  beforeEach(() => {
+    stderrData = "";
+    exitCode = undefined;
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+    mkdirSync(TMP_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    if (existsSync(TMP_DIR)) {
+      rmSync(TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a valid snapshot to the --baseline path", async () => {
+    const outPath = resolve(TMP_DIR, "baseline.mcpc.json");
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "update",
+      "--baseline",
+      outPath,
+      "--command",
+      "node",
+    ]);
+    const snapshot = JSON.parse(readFileSync(outPath, "utf-8"));
+    expect(snapshot.snapshotVersion).toBe("1.0.0");
+    expect(snapshot.server.name).toBe("test-server");
+    expect(snapshot.contentHash).toMatch(/^sha256:/);
+    expect(Object.keys(snapshot.tools)).toContain("test_tool");
+    expect(stderrData).toContain(`Baseline written to ${outPath}`);
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("accepts the global -o option for the output path", async () => {
+    const outPath = resolve(TMP_DIR, "via-output.mcpc.json");
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "-o", outPath, "update", "--command", "node"]);
+    expect(existsSync(outPath)).toBe(true);
+  });
+
+  it("prefers --baseline over the global -o option", async () => {
+    const baselinePath = resolve(TMP_DIR, "from-baseline.mcpc.json");
+    const outputPath = resolve(TMP_DIR, "from-output.mcpc.json");
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "-o",
+      outputPath,
+      "update",
+      "--baseline",
+      baselinePath,
+      "--command",
+      "node",
+    ]);
+    expect(existsSync(baselinePath)).toBe(true);
+    expect(existsSync(outputPath)).toBe(false);
+  });
+
+  it("creates missing directories", async () => {
+    const nestedPath = resolve(TMP_DIR, "nested/dir/baseline.mcpc.json");
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "update",
+      "--baseline",
+      nestedPath,
+      "--command",
+      "node",
+    ]);
+    expect(existsSync(nestedPath)).toBe(true);
+  });
+
+  it("resolves the baseline path from the project config", async () => {
+    const projectPath = resolve(TMP_DIR, "mcpcontracts.json");
+    writeFileSync(
+      projectPath,
+      JSON.stringify({ baseline: "contracts/config-baseline.mcpc.json" }),
+      "utf-8",
+    );
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--project",
+      projectPath,
+      "update",
+      "--command",
+      "node",
+    ]);
+    expect(existsSync(resolve(TMP_DIR, "contracts/config-baseline.mcpc.json"))).toBe(true);
+  });
+
+  it("errors with exit 2 when no transport is available", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "update",
+        "--baseline",
+        resolve(TMP_DIR, "x.mcpc.json"),
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Specify one of");
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,55 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { Command } from "commander";
+import {
+  DEFAULT_BASELINE_PATH,
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import { getRootOpts, handleErrors, writeOutput } from "../utils.js";
+import { captureSnapshot } from "./capture.js";
+
+/**
+ * Creates the `update` subcommand for the mcpdiff CLI.
+ *
+ * Captures a snapshot from the live server and writes it as the baseline.
+ * The path comes from --baseline, then the global --output option, then the
+ * project config's "baseline", then contracts/baseline.mcpc.json. For ad-hoc
+ * snapshots that are not baselines, use `snapshot -o <file>`.
+ *
+ * @returns A Commander Command instance for the update subcommand.
+ */
+export function createUpdateCommand(): Command {
+  const cmd = new Command("update").description("Capture the live server and write the baseline");
+
+  addTransportOptions(cmd);
+
+  cmd
+    .option("--baseline <path>", `Path to write the baseline (default: "${DEFAULT_BASELINE_PATH}")`)
+    .action(
+      handleErrors(async (options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const quiet = rootOpts["quiet"] === true;
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+
+        const flagPath =
+          (options["baseline"] as string | undefined) ?? (rootOpts["output"] as string | undefined);
+        const outputPath = resolveBaselinePath(flagPath, project) ?? DEFAULT_BASELINE_PATH;
+
+        const transport = resolveTransportOrProject(options, project);
+
+        const { snapshot } = await captureSnapshot({ transport, quiet });
+
+        mkdirSync(dirname(outputPath), { recursive: true });
+        writeOutput(`${JSON.stringify(snapshot, null, 2)}\n`, outputPath);
+
+        if (!quiet) {
+          process.stderr.write(`Baseline written to ${outputPath}\n`);
+        }
+      }),
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/commands/verify-hash.test.ts
+++ b/packages/cli/src/commands/verify-hash.test.ts
@@ -70,6 +70,13 @@ describe("verify-hash command", () => {
     vi.restoreAllMocks();
   });
 
+  it("prints a deprecation notice pointing at verify", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "verify-hash", validPath, "--format", "terminal"]);
+    expect(stderrData).toContain("deprecated");
+    expect(stderrData).toContain("mcpdiff verify");
+  });
+
   it("passes for a valid snapshot (terminal)", async () => {
     const program = createProgram();
     await program.parseAsync(["node", "mcpdiff", "verify-hash", validPath, "--format", "terminal"]);

--- a/packages/cli/src/commands/verify-hash.ts
+++ b/packages/cli/src/commands/verify-hash.ts
@@ -2,7 +2,9 @@ import { verifyContentHash } from "@mcp-contracts/core";
 import { Command } from "commander";
 import {
   CliExitError,
+  getRootOpts,
   handleErrors,
+  printDeprecationNotice,
   readSnapshotFile,
   resolveFormat,
   writeOutput,
@@ -23,6 +25,9 @@ export function createVerifyHashCommand(): Command {
     .action(
       handleErrors(async (snapshotPath: string) => {
         const rootOpts = getRootOpts(cmd);
+        if (rootOpts["quiet"] !== true) {
+          printDeprecationNotice("mcpdiff verify-hash", "mcpdiff verify");
+        }
         const format = resolveFormat(rootOpts["format"] as string | undefined);
         const outputPath = rootOpts["output"] as string | undefined;
 
@@ -46,18 +51,4 @@ export function createVerifyHashCommand(): Command {
     );
 
   return cmd;
-}
-
-/**
- * Resolves the root program options from a deeply nested subcommand.
- *
- * @param cmd - The current Command instance.
- * @returns The root program's parsed options.
- */
-function getRootOpts(cmd: Command): Record<string, unknown> {
-  let current: Command | null = cmd;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
 }

--- a/packages/cli/src/commands/verify.test.ts
+++ b/packages/cli/src/commands/verify.test.ts
@@ -75,6 +75,8 @@ describe("verify command", () => {
     await program.parseAsync([
       "node",
       "mcpdiff",
+      "--format",
+      "terminal",
       "verify",
       validSnapshotPath,
       "--key",
@@ -99,6 +101,8 @@ describe("verify command", () => {
       await program.parseAsync([
         "node",
         "mcpdiff",
+        "--format",
+        "terminal",
         "verify",
         validSnapshotPath,
         "--key",
@@ -151,5 +155,93 @@ describe("verify command", () => {
     }
     expect(exitCode).toBe(2);
     expect(stderrData).toContain("Failed to read key file");
+  });
+});
+
+describe("verify command — hash-only mode (no --key)", () => {
+  let stdoutData: string;
+  let stderrData: string;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    stdoutData = "";
+    stderrData = "";
+    exitCode = undefined;
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutData += String(chunk);
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("verifies the content hash and notes the signature was not checked", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "terminal",
+      "verify",
+      validSnapshotPath,
+    ]);
+    expect(stdoutData).toContain("Content hash verified");
+    expect(stderrData).toContain("only the content hash was checked");
+    expect(stderrData).toContain("--key");
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("exits 1 on a tampered snapshot", async () => {
+    const snapshot = JSON.parse(readFileSync(validSnapshotPath, "utf-8"));
+    snapshot.contentHash =
+      "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    const tamperedPath = join(tmpDir, "tampered.mcpc.json");
+    writeFileSync(tamperedPath, JSON.stringify(snapshot, null, 2));
+
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "--format", "terminal", "verify", tamperedPath]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+    expect(stderrData).toContain("Content hash mismatch");
+  });
+
+  it("reports checks: [hash] in JSON output", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "--format", "json", "verify", validSnapshotPath]);
+    const result = JSON.parse(stdoutData);
+    expect(result.valid).toBe(true);
+    expect(result.checks).toEqual(["hash"]);
+  });
+
+  it("reports checks: [hash, binding, signature] in JSON output with --key", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "verify",
+      validSnapshotPath,
+      "--key",
+      ed25519PublicPath,
+      "--signature",
+      sigPath,
+    ]);
+    const result = JSON.parse(stdoutData);
+    expect(result.valid).toBe(true);
+    expect(result.checks).toEqual(["hash", "binding", "signature"]);
   });
 });

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,56 +1,141 @@
 import { readFileSync } from "node:fs";
-import { parseSignatureFile, verifySignature } from "@mcp-contracts/core";
+import { parseSignatureFile, verifyContentHash, verifySignature } from "@mcp-contracts/core";
 import { Command } from "commander";
-import { CliExitError, handleErrors, readSnapshotFile } from "../utils.js";
+import {
+  CliExitError,
+  getRootOpts,
+  handleErrors,
+  readSnapshotFile,
+  resolveFormat,
+  writeOutput,
+} from "../utils.js";
 import { deriveSignaturePath } from "./sign.js";
+
+/** The checks performed by a verify run, in execution order. */
+const HASH_ONLY_CHECKS = ["hash"] as const;
+const SIGNATURE_CHECKS = ["hash", "binding", "signature"] as const;
+
+/**
+ * Runs the content-hash-only verification (no key given).
+ *
+ * @param snapshotPath - Path to the snapshot file.
+ * @param format - Resolved output format.
+ * @param outputPath - Output file path, or undefined for stdout.
+ */
+function verifyHashOnly(
+  snapshotPath: string,
+  format: string,
+  outputPath: string | undefined,
+): void {
+  const snapshot = readSnapshotFile(snapshotPath);
+  const result = verifyContentHash(snapshot);
+
+  if (format === "json") {
+    const output = { ...result, checks: [...HASH_ONLY_CHECKS] };
+    writeOutput(`${JSON.stringify(output, null, 2)}\n`, outputPath);
+  } else if (result.valid) {
+    writeOutput(`Content hash verified: ${result.actual}\n`, outputPath);
+    process.stderr.write(
+      "Note: only the content hash was checked; pass --key to verify a signature\n",
+    );
+  } else {
+    process.stderr.write(
+      `Content hash mismatch!\n  Expected: ${result.expected}\n  Actual:   ${result.actual}\n`,
+    );
+  }
+
+  if (!result.valid) {
+    throw new CliExitError(1);
+  }
+}
+
+/**
+ * Runs the full signature verification (hash + binding + signature).
+ *
+ * @param snapshotPath - Path to the snapshot file.
+ * @param keyPath - Path to the public key file.
+ * @param signaturePath - Explicit signature path, or undefined to derive it.
+ * @param format - Resolved output format.
+ * @param outputPath - Output file path, or undefined for stdout.
+ */
+function verifyWithKey(
+  snapshotPath: string,
+  keyPath: string,
+  signaturePath: string | undefined,
+  format: string,
+  outputPath: string | undefined,
+): void {
+  const snapshot = readSnapshotFile(snapshotPath);
+
+  let keyPem: string;
+  try {
+    keyPem = readFileSync(keyPath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read key file: ${message}`);
+  }
+
+  const sigPath = signaturePath ?? deriveSignaturePath(snapshotPath);
+
+  let sigJson: string;
+  try {
+    sigJson = readFileSync(sigPath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read signature file "${sigPath}": ${message}`);
+  }
+
+  const sig = parseSignatureFile(sigJson);
+  const result = verifySignature(snapshot, sig, keyPem);
+
+  if (format === "json") {
+    const output = { ...result, checks: [...SIGNATURE_CHECKS] };
+    writeOutput(`${JSON.stringify(output, null, 2)}\n`, outputPath);
+  } else if (result.valid) {
+    process.stderr.write(`Signature verified: ${sig.algorithm} signature is valid\n`);
+  } else {
+    process.stderr.write(`Signature verification failed: ${result.error}\n`);
+  }
+
+  if (!result.valid) {
+    throw new CliExitError(1);
+  }
+}
 
 /**
  * Creates the `verify` subcommand for the mcpdiff CLI.
  *
- * Verifies a snapshot's detached signature using a public key.
- * Checks content hash integrity, hash binding, and cryptographic signature.
+ * Verifies the integrity/authenticity of a snapshot file. Without --key,
+ * checks the content hash only. With --key, additionally verifies the
+ * detached signature (hash + binding + cryptographic check).
  *
  * @returns A Commander Command instance for the verify subcommand.
  */
 export function createVerifyCommand(): Command {
   const cmd = new Command("verify")
-    .description("Verify a snapshot's signature with a public key")
+    .description("Verify a snapshot's integrity (content hash, plus signature with --key)")
     .argument("<snapshot>", "Path to the snapshot file (.mcpc.json)")
-    .requiredOption("--key <path>", "Path to public key (PEM format, Ed25519 or RSA)")
+    .option("--key <path>", "Path to public key (PEM format, Ed25519 or RSA)")
     .option("--signature <path>", "Path to signature file (default: <snapshot>.mcpc.sig)")
     .action(
       handleErrors(async (snapshotPath: string, options: Record<string, unknown>) => {
-        const snapshot = readSnapshotFile(snapshotPath);
+        const rootOpts = getRootOpts(cmd);
+        const format = resolveFormat(rootOpts["format"] as string | undefined);
+        const outputPath = rootOpts["output"] as string | undefined;
 
-        let keyPem: string;
-        try {
-          keyPem = readFileSync(options["key"] as string, "utf-8");
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          throw new Error(`Failed to read key file: ${message}`);
-        }
-
-        const sigPath =
-          (options["signature"] as string | undefined) ?? deriveSignaturePath(snapshotPath);
-
-        let sigJson: string;
-        try {
-          sigJson = readFileSync(sigPath, "utf-8");
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          throw new Error(`Failed to read signature file "${sigPath}": ${message}`);
-        }
-
-        const sig = parseSignatureFile(sigJson);
-        const result = verifySignature(snapshot, sig, keyPem);
-
-        if (result.valid) {
-          process.stderr.write(`Signature verified: ${sig.algorithm} signature is valid\n`);
+        const keyPath = options["key"] as string | undefined;
+        if (!keyPath) {
+          verifyHashOnly(snapshotPath, format, outputPath);
           return;
         }
 
-        process.stderr.write(`Signature verification failed: ${result.error}\n`);
-        throw new CliExitError(1);
+        verifyWithKey(
+          snapshotPath,
+          keyPath,
+          options["signature"] as string | undefined,
+          format,
+          outputPath,
+        );
       }),
     );
 

--- a/packages/cli/src/commands/watch.test.ts
+++ b/packages/cli/src/commands/watch.test.ts
@@ -41,11 +41,12 @@ describe("watch command", () => {
     expect(baselineOpt?.required).toBe(true);
   });
 
-  it("defaults --debounce to 500", () => {
+  it("has no commander default for --debounce so the project config can supply it", () => {
     const program = createProgram();
     const watchCmd = program.commands.find((c) => c.name() === "watch");
     const debounceOpt = watchCmd?.options.find((o) => o.long === "--debounce");
-    expect(debounceOpt?.defaultValue).toBe("500");
+    expect(debounceOpt?.defaultValue).toBeUndefined();
+    expect(debounceOpt?.description).toContain("500");
   });
 
   it("defaults --severity to safe", () => {
@@ -55,17 +56,19 @@ describe("watch command", () => {
     expect(severityOpt?.defaultValue).toBe("safe");
   });
 
-  it("defaults --fail-on to breaking", () => {
+  it("has no commander default for --fail-on so the project config can supply it", () => {
     const program = createProgram();
     const watchCmd = program.commands.find((c) => c.name() === "watch");
     const failOnOpt = watchCmd?.options.find((o) => o.long === "--fail-on");
-    expect(failOnOpt?.defaultValue).toBe("breaking");
+    expect(failOnOpt?.defaultValue).toBeUndefined();
+    expect(failOnOpt?.description).toContain("breaking");
   });
 
-  it("defaults --watch-paths to current directory", () => {
+  it("has no commander default for --watch-paths so the project config can supply it", () => {
     const program = createProgram();
     const watchCmd = program.commands.find((c) => c.name() === "watch");
     const watchPathsOpt = watchCmd?.options.find((o) => o.long === "--watch-paths");
-    expect(watchPathsOpt?.defaultValue).toEqual(["."]);
+    expect(watchPathsOpt?.defaultValue).toBeUndefined();
+    expect(watchPathsOpt?.description).toContain(".");
   });
 });

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -9,7 +9,7 @@ import {
   resolveTransportOrProject,
 } from "../project-config.js";
 import { addTransportOptions } from "../transport.js";
-import { getRootOpts, handleErrors, parseSeverity } from "../utils.js";
+import { getRootOpts, handleErrors, parseSeverity, printDeprecationNotice } from "../utils.js";
 import { runWatchLoop } from "../watch-loop.js";
 
 /** Watch options resolved from CLI flags and the project config. */
@@ -85,6 +85,9 @@ export function createWatchCommand(): Command {
       handleErrors(async (options: Record<string, unknown>) => {
         const rootOpts = getRootOpts(cmd);
         const quiet = rootOpts["quiet"] === true;
+        if (!quiet) {
+          printDeprecationNotice("mcpdiff watch", "mcpdiff check --watch");
+        }
         const project = loadProjectConfig(rootOpts["project"] as string | undefined);
 
         const { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear } =

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -16,9 +16,15 @@ import {
   SEVERITY_ORDER,
 } from "@mcp-contracts/core";
 import { Command } from "commander";
-import type { TransportOptions } from "../transport.js";
-import { addTransportOptions, resolveTransport } from "../transport.js";
-import { handleErrors, readSnapshotFile } from "../utils.js";
+import type { LoadedProjectConfig } from "../project-config.js";
+import {
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveProjectPath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import { getRootOpts, handleErrors, readSnapshotFile } from "../utils.js";
 import {
   clearScreen,
   formatWatchCycle,
@@ -112,6 +118,53 @@ function checkFailThreshold(
   }
 }
 
+/** Watch options resolved from CLI flags and the project config. */
+interface ResolvedWatchOptions {
+  severity: Severity;
+  failOn: Severity;
+  debounceMs: number;
+  watchPaths: string[];
+  baselinePath: string;
+  webhookUrl: string | undefined;
+  shouldClear: boolean;
+}
+
+/**
+ * Resolves the watch command's options with flags > project config > defaults
+ * precedence.
+ *
+ * @param options - The raw parsed options record from the command action.
+ * @param project - The loaded project config, if any.
+ * @returns The fully resolved watch options.
+ */
+function resolveWatchOptions(
+  options: Record<string, unknown>,
+  project: LoadedProjectConfig | null,
+): ResolvedWatchOptions {
+  const severity = parseSeverity((options["severity"] as string) ?? "safe", "--severity");
+  const failOn = parseSeverity(
+    (options["failOn"] as string | undefined) ?? project?.config.failOn ?? "breaking",
+    "--fail-on",
+  );
+  const debounceMs = Number.parseInt(
+    (options["debounce"] as string | undefined) ?? String(project?.config.watch?.debounce ?? 500),
+    10,
+  );
+  const projectWatchPaths = project?.config.watch?.paths?.map((p) =>
+    resolveProjectPath(project, p),
+  );
+  const watchPaths = (options["watchPaths"] as string[] | undefined) ?? projectWatchPaths ?? ["."];
+  const baselinePath = resolveBaselinePath(options["baseline"] as string | undefined, project);
+  if (!baselinePath) {
+    throw new Error('--baseline is required (or set "baseline" in mcpcontracts.json)');
+  }
+  const webhookUrl = options["webhook"] as string | undefined;
+  const shouldClear =
+    options["clear"] === true || (options["clear"] === undefined && process.stdout.isTTY);
+
+  return { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear };
+}
+
 /**
  * Creates the `watch` subcommand for the mcpdiff CLI.
  *
@@ -128,26 +181,21 @@ export function createWatchCommand(): Command {
   addTransportOptions(cmd);
 
   cmd
-    .requiredOption("--baseline <path>", "Path to baseline snapshot")
-    .option("--watch-paths <paths...>", "Paths to watch for changes", ["."])
-    .option("--debounce <ms>", "Debounce interval in milliseconds", "500")
+    .option("--baseline <path>", "Path to baseline snapshot")
+    .option("--watch-paths <paths...>", 'Paths to watch for changes (default: ".")')
+    .option("--debounce <ms>", "Debounce interval in milliseconds (default: 500)")
     .option("--severity <level>", "Minimum severity to display", "safe")
-    .option("--fail-on <level>", "Severity threshold", "breaking")
+    .option("--fail-on <level>", 'Severity threshold (default: "breaking")')
     .option("--webhook <url>", "POST diffs on each cycle")
     .option("--clear", "Clear screen between diffs")
     .action(
       handleErrors(async (options: Record<string, unknown>) => {
-        const parentOpts = cmd.parent?.opts() ?? {};
-        const quiet = parentOpts["quiet"] === true;
+        const rootOpts = getRootOpts(cmd);
+        const quiet = rootOpts["quiet"] === true;
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
 
-        const severity = parseSeverity((options["severity"] as string) ?? "safe", "--severity");
-        const failOn = parseSeverity((options["failOn"] as string) ?? "breaking", "--fail-on");
-        const debounceMs = Number.parseInt(options["debounce"] as string, 10);
-        const watchPaths = options["watchPaths"] as string[];
-        const baselinePath = options["baseline"] as string;
-        const webhookUrl = options["webhook"] as string | undefined;
-        const shouldClear =
-          options["clear"] === true || (options["clear"] === undefined && process.stdout.isTTY);
+        const { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear } =
+          resolveWatchOptions(options, project);
 
         const config = createWatchConfig({
           debounceMs,
@@ -156,17 +204,7 @@ export function createWatchCommand(): Command {
           failOn,
         });
 
-        const transportOpts: TransportOptions = {
-          command: options["command"] as string | undefined,
-          url: options["url"] as string | undefined,
-          config: options["config"] as string | undefined,
-          server: options["server"] as string | undefined,
-          args: options["args"] as string[] | undefined,
-          env: options["env"] as string[] | undefined,
-          sse: options["sse"] === true ? true : undefined,
-          header: options["header"] as string[] | undefined,
-        };
-        const transport = resolveTransport(transportOpts);
+        const transport = resolveTransportOrProject(options, project);
 
         // Print header
         process.stderr.write(formatWatchHeader(baselinePath, watchPaths, debounceMs));

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -2,6 +2,7 @@ import type { Severity } from "@mcp-contracts/core";
 import { Command } from "commander";
 import type { LoadedProjectConfig } from "../project-config.js";
 import {
+  DEFAULT_BASELINE_PATH,
   loadProjectConfig,
   resolveBaselinePath,
   resolveProjectPath,
@@ -47,10 +48,9 @@ export function resolveWatchOptions(
     resolveProjectPath(project, p),
   );
   const watchPaths = (options["watchPaths"] as string[] | undefined) ?? projectWatchPaths ?? ["."];
-  const baselinePath = resolveBaselinePath(options["baseline"] as string | undefined, project);
-  if (!baselinePath) {
-    throw new Error('--baseline is required (or set "baseline" in mcpcontracts.json)');
-  }
+  const baselinePath =
+    resolveBaselinePath(options["baseline"] as string | undefined, project) ??
+    DEFAULT_BASELINE_PATH;
   const webhookUrl = options["webhook"] as string | undefined;
   const shouldClear =
     options["clear"] === true || (options["clear"] === undefined && process.stdout.isTTY);
@@ -74,7 +74,7 @@ export function createWatchCommand(): Command {
   addTransportOptions(cmd);
 
   cmd
-    .option("--baseline <path>", "Path to baseline snapshot")
+    .option("--baseline <path>", `Path to baseline snapshot (default: "${DEFAULT_BASELINE_PATH}")`)
     .option("--watch-paths <paths...>", 'Paths to watch for changes (default: ".")')
     .option("--debounce <ms>", "Debounce interval in milliseconds (default: 500)")
     .option("--severity <level>", "Minimum severity to display", "safe")

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -1,20 +1,4 @@
-import { watch } from "node:fs/promises";
-import { resolve } from "node:path";
-import type {
-  DiffReport,
-  MCPContractSnapshot,
-  Severity,
-  WatchConfig,
-  WatchDiffEvent,
-} from "@mcp-contracts/core";
-import {
-  createWatchConfig,
-  createWebhookPayload,
-  DEFAULT_WATCH_IGNORE_PATTERNS,
-  diffSnapshots,
-  formatTerminal,
-  SEVERITY_ORDER,
-} from "@mcp-contracts/core";
+import type { Severity } from "@mcp-contracts/core";
 import { Command } from "commander";
 import type { LoadedProjectConfig } from "../project-config.js";
 import {
@@ -24,99 +8,8 @@ import {
   resolveTransportOrProject,
 } from "../project-config.js";
 import { addTransportOptions } from "../transport.js";
-import { getRootOpts, handleErrors, readSnapshotFile } from "../utils.js";
-import {
-  clearScreen,
-  formatWatchCycle,
-  formatWatchError,
-  formatWatchHeader,
-} from "../watch-output.js";
-import { sendWebhook } from "../webhook.js";
-import { captureSnapshot } from "./capture.js";
-
-const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
-
-/**
- * Validates that a string is a valid Severity level.
- *
- * @param value - The string to validate.
- * @param label - Label for the option (used in error messages).
- * @returns The validated Severity value.
- */
-function parseSeverity(value: string, label: string): Severity {
-  if (!VALID_SEVERITIES.has(value)) {
-    throw new Error(`Invalid ${label} value "${value}". Must be one of: safe, warning, breaking`);
-  }
-  return value as Severity;
-}
-
-/**
- * Checks if a file path matches any of the ignore patterns.
- *
- * @param filePath - The file path to check.
- * @param patterns - Glob-like patterns to match against.
- * @returns True if the path should be ignored.
- */
-function shouldIgnore(filePath: string, patterns: string[]): boolean {
-  for (const pattern of patterns) {
-    // Simple glob matching: convert ** and * to regex
-    const escaped = pattern
-      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-      .replace(/\*\*/g, "{{GLOBSTAR}}")
-      .replace(/\*/g, "[^/]*")
-      .replace(/\{\{GLOBSTAR\}\}/g, ".*");
-    const regex = new RegExp(escaped);
-    if (regex.test(filePath)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Sends a webhook notification for a diff report if configured.
- *
- * @param webhookUrl - The URL to POST to, or undefined to skip.
- * @param report - The diff report to send.
- * @param baselinePath - Path to the baseline snapshot file.
- */
-async function maybeSendWebhook(
-  webhookUrl: string | undefined,
-  report: DiffReport,
-  baselinePath: string,
-): Promise<void> {
-  if (!webhookUrl) return;
-  const payload = createWebhookPayload(report, {
-    trigger: "watch",
-    baselinePath,
-  });
-  const result = await sendWebhook(webhookUrl, payload);
-  if (!result.success) {
-    process.stderr.write(`Warning: Webhook failed: ${result.error}\n`);
-  }
-}
-
-/**
- * Checks if a diff report contains changes above the fail threshold and warns.
- *
- * @param baseline - The baseline snapshot.
- * @param current - The current snapshot.
- * @param config - Watch configuration.
- * @param quiet - Whether to suppress output.
- */
-function checkFailThreshold(
-  baseline: MCPContractSnapshot,
-  current: MCPContractSnapshot,
-  config: WatchConfig,
-  quiet: boolean,
-): void {
-  const fullReport = diffSnapshots(baseline, current);
-  const failThreshold = SEVERITY_ORDER[config.failOn];
-  const hasFailure = fullReport.changes.some((c) => SEVERITY_ORDER[c.severity] >= failThreshold);
-  if (hasFailure && !quiet) {
-    process.stderr.write("Breaking changes detected!\n");
-  }
-}
+import { getRootOpts, handleErrors, parseSeverity } from "../utils.js";
+import { runWatchLoop } from "../watch-loop.js";
 
 /** Watch options resolved from CLI flags and the project config. */
 interface ResolvedWatchOptions {
@@ -137,7 +30,7 @@ interface ResolvedWatchOptions {
  * @param project - The loaded project config, if any.
  * @returns The fully resolved watch options.
  */
-function resolveWatchOptions(
+export function resolveWatchOptions(
   options: Record<string, unknown>,
   project: LoadedProjectConfig | null,
 ): ResolvedWatchOptions {
@@ -197,117 +90,19 @@ export function createWatchCommand(): Command {
         const { severity, failOn, debounceMs, watchPaths, baselinePath, webhookUrl, shouldClear } =
           resolveWatchOptions(options, project);
 
-        const config = createWatchConfig({
-          debounceMs,
-          watchPaths,
-          minSeverity: severity,
-          failOn,
-        });
-
         const transport = resolveTransportOrProject(options, project);
 
-        // Print header
-        process.stderr.write(formatWatchHeader(baselinePath, watchPaths, debounceMs));
-
-        // Set up abort controller for graceful shutdown
-        const ac = new AbortController();
-
-        const shutdown = () => {
-          process.stderr.write("\nShutting down watch mode...\n");
-          ac.abort();
-        };
-        process.on("SIGINT", shutdown);
-        process.on("SIGTERM", shutdown);
-
-        let cycle = 0;
-        let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-        let pendingPaths: string[] = [];
-
-        /**
-         * Runs a single diff cycle.
-         *
-         * @param triggerPaths - File paths that triggered this cycle.
-         */
-        async function runCycle(triggerPaths: string[]): Promise<void> {
-          cycle++;
-          const start = Date.now();
-
-          let event: WatchDiffEvent;
-
-          try {
-            const baseline = readSnapshotFile(baselinePath);
-            const { snapshot: current } = await captureSnapshot({ transport, quiet: true });
-            const report = diffSnapshots(baseline, current, { minSeverity: config.minSeverity });
-
-            event = {
-              cycle,
-              timestamp: new Date().toISOString(),
-              report,
-              triggerPaths,
-              durationMs: Date.now() - start,
-            };
-
-            if (shouldClear) {
-              process.stdout.write(clearScreen());
-            }
-
-            process.stdout.write(formatWatchCycle(event, formatTerminal));
-
-            await maybeSendWebhook(webhookUrl, report, baselinePath);
-            checkFailThreshold(baseline, current, config, quiet);
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            event = {
-              cycle,
-              timestamp: new Date().toISOString(),
-              triggerPaths,
-              durationMs: Date.now() - start,
-              error: message,
-            };
-            process.stderr.write(formatWatchError(event));
-          }
-        }
-
-        // Start watching
-        const resolvedPaths = watchPaths.map((p) => resolve(p));
-        const watchers = resolvedPaths.map((p) => watch(p, { recursive: true, signal: ac.signal }));
-
-        try {
-          // Use Promise.race of all watchers to handle events
-          const watcherPromises = watchers.map(async (watcher) => {
-            for await (const event of watcher) {
-              if (ac.signal.aborted) break;
-              const filename = event.filename ?? "";
-              if (shouldIgnore(filename, [...DEFAULT_WATCH_IGNORE_PATTERNS])) {
-                continue;
-              }
-              pendingPaths.push(filename);
-
-              if (debounceTimer) {
-                clearTimeout(debounceTimer);
-              }
-              debounceTimer = setTimeout(() => {
-                const paths = [...pendingPaths];
-                pendingPaths = [];
-                runCycle(paths);
-              }, config.debounceMs);
-            }
-          });
-
-          await Promise.all(watcherPromises);
-        } catch (err) {
-          if (err instanceof Error && err.name === "AbortError") {
-            // Expected on shutdown
-          } else {
-            throw err;
-          }
-        } finally {
-          process.removeListener("SIGINT", shutdown);
-          process.removeListener("SIGTERM", shutdown);
-          if (debounceTimer) {
-            clearTimeout(debounceTimer);
-          }
-        }
+        await runWatchLoop({
+          transport,
+          baselinePath,
+          watchPaths,
+          debounceMs,
+          minSeverity: severity,
+          failOn,
+          webhookUrl,
+          shouldClear,
+          quiet,
+        });
       }),
     );
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { createInitCommand } from "./commands/init.js";
 import { createInspectCommand } from "./commands/inspect.js";
 import { createSignCommand } from "./commands/sign.js";
 import { createSnapshotCommand } from "./commands/snapshot.js";
+import { createTestCommand } from "./commands/test.js";
 import { createUpdateCommand } from "./commands/update.js";
 import { createVerifyCommand } from "./commands/verify.js";
 import { createVerifyHashCommand } from "./commands/verify-hash.js";
@@ -41,6 +42,7 @@ program
 program.addCommand(createInitCommand());
 program.addCommand(createCheckCommand());
 program.addCommand(createUpdateCommand());
+program.addCommand(createTestCommand());
 program.addCommand(createBaselineCommand(), { hidden: true });
 program.addCommand(createCheckConflictsCommand());
 program.addCommand(createCiCommand(), { hidden: true });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,11 @@ program
   .option("--no-color", "Disable colored output")
   .option("-o, --output <path>", "Output file path")
   .option("--quiet", "Suppress non-essential output")
-  .option("--verbose", "Show detailed information");
+  .option("--verbose", "Show detailed information")
+  .option(
+    "--project <path>",
+    "Path to mcpcontracts.json (default: discovered by walking up from the CWD)",
+  );
 
 program.addCommand(createBaselineCommand());
 program.addCommand(createCheckConflictsCommand());

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,7 +48,7 @@ program.addCommand(createInspectCommand());
 program.addCommand(createSignCommand());
 program.addCommand(createSnapshotCommand());
 program.addCommand(createVerifyCommand());
-program.addCommand(createVerifyHashCommand());
+program.addCommand(createVerifyHashCommand(), { hidden: true });
 program.addCommand(createWatchCommand(), { hidden: true });
 
 program.parse();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,9 +39,9 @@ program
 
 program.addCommand(createCheckCommand());
 program.addCommand(createUpdateCommand());
-program.addCommand(createBaselineCommand());
+program.addCommand(createBaselineCommand(), { hidden: true });
 program.addCommand(createCheckConflictsCommand());
-program.addCommand(createCiCommand());
+program.addCommand(createCiCommand(), { hidden: true });
 program.addCommand(createDiffCommand());
 program.addCommand(createGraphCommand());
 program.addCommand(createInspectCommand());
@@ -49,6 +49,6 @@ program.addCommand(createSignCommand());
 program.addCommand(createSnapshotCommand());
 program.addCommand(createVerifyCommand());
 program.addCommand(createVerifyHashCommand());
-program.addCommand(createWatchCommand());
+program.addCommand(createWatchCommand(), { hidden: true });
 
 program.parse();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,7 +28,7 @@ const program = new Command();
 program
   .name("mcpdiff")
   .description("Capture, diff, and inspect MCP server tool schemas")
-  .version("0.6.0")
+  .version("0.7.0")
   .option("--format <format>", "Output format: terminal | json | markdown")
   .option("--no-color", "Disable colored output")
   .option("-o, --output <path>", "Output file path")

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { createCheckConflictsCommand } from "./commands/check-conflicts.js";
 import { createCiCommand } from "./commands/ci.js";
 import { createDiffCommand } from "./commands/diff.js";
 import { createGraphCommand } from "./commands/graph.js";
+import { createInitCommand } from "./commands/init.js";
 import { createInspectCommand } from "./commands/inspect.js";
 import { createSignCommand } from "./commands/sign.js";
 import { createSnapshotCommand } from "./commands/snapshot.js";
@@ -37,6 +38,7 @@ program
     "Path to mcpcontracts.json (default: discovered by walking up from the CWD)",
   );
 
+program.addCommand(createInitCommand());
 program.addCommand(createCheckCommand());
 program.addCommand(createUpdateCommand());
 program.addCommand(createBaselineCommand(), { hidden: true });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@
 
 import { Command } from "commander";
 import { createBaselineCommand } from "./commands/baseline.js";
+import { createCheckCommand } from "./commands/check.js";
 import { createCheckConflictsCommand } from "./commands/check-conflicts.js";
 import { createCiCommand } from "./commands/ci.js";
 import { createDiffCommand } from "./commands/diff.js";
@@ -15,6 +16,7 @@ import { createGraphCommand } from "./commands/graph.js";
 import { createInspectCommand } from "./commands/inspect.js";
 import { createSignCommand } from "./commands/sign.js";
 import { createSnapshotCommand } from "./commands/snapshot.js";
+import { createUpdateCommand } from "./commands/update.js";
 import { createVerifyCommand } from "./commands/verify.js";
 import { createVerifyHashCommand } from "./commands/verify-hash.js";
 import { createWatchCommand } from "./commands/watch.js";
@@ -35,6 +37,8 @@ program
     "Path to mcpcontracts.json (default: discovered by walking up from the CWD)",
   );
 
+program.addCommand(createCheckCommand());
+program.addCommand(createUpdateCommand());
 program.addCommand(createBaselineCommand());
 program.addCommand(createCheckConflictsCommand());
 program.addCommand(createCiCommand());

--- a/packages/cli/src/project-config.test.ts
+++ b/packages/cli/src/project-config.test.ts
@@ -1,0 +1,219 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  discoverProjectConfig,
+  type LoadedProjectConfig,
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveProjectTransport,
+  resolveTransportOrProject,
+} from "./project-config.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mcpc-project-config-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeConfig(targetDir: string, config: unknown): string {
+  const path = join(targetDir, "mcpcontracts.json");
+  writeFileSync(path, JSON.stringify(config, null, 2), "utf-8");
+  return path;
+}
+
+function loaded(config: Record<string, unknown>): LoadedProjectConfig {
+  const path = writeConfig(dir, config);
+  const result = loadProjectConfig(path);
+  if (!result) {
+    throw new Error("expected config to load");
+  }
+  return result;
+}
+
+describe("discoverProjectConfig", () => {
+  it("finds the config in the start directory", () => {
+    const path = writeConfig(dir, {});
+    expect(discoverProjectConfig(dir)).toBe(resolve(path));
+  });
+
+  it("walks up to a parent directory", () => {
+    const path = writeConfig(dir, {});
+    const nested = join(dir, "a", "b");
+    mkdirSync(nested, { recursive: true });
+    expect(discoverProjectConfig(nested)).toBe(resolve(path));
+  });
+
+  it("prefers the nearest config", () => {
+    writeConfig(dir, {});
+    const nested = join(dir, "sub");
+    mkdirSync(nested);
+    const nearest = writeConfig(nested, {});
+    expect(discoverProjectConfig(nested)).toBe(resolve(nearest));
+  });
+
+  it("returns null when no config exists", () => {
+    expect(discoverProjectConfig(dir)).toBeNull();
+  });
+});
+
+describe("loadProjectConfig", () => {
+  it("returns null when discovery finds nothing", () => {
+    expect(loadProjectConfig(undefined, dir)).toBeNull();
+  });
+
+  it("discovers and loads a valid config", () => {
+    writeConfig(dir, { baseline: "contracts/baseline.mcpc.json" });
+    const result = loadProjectConfig(undefined, dir);
+    expect(result?.config.baseline).toBe("contracts/baseline.mcpc.json");
+    expect(result?.dir).toBe(resolve(dir));
+  });
+
+  it("throws when an explicit path does not exist", () => {
+    expect(() => loadProjectConfig(join(dir, "missing.json"))).toThrow(/not found/);
+  });
+
+  it("loads an explicit path relative to the cwd", () => {
+    const nested = join(dir, "configs");
+    mkdirSync(nested);
+    writeConfig(nested, { failOn: "warning" });
+    const result = loadProjectConfig(join("configs", "mcpcontracts.json"), dir);
+    expect(result?.config.failOn).toBe("warning");
+  });
+
+  it("throws on invalid JSON, naming the file", () => {
+    const path = join(dir, "mcpcontracts.json");
+    writeFileSync(path, "{ not json", "utf-8");
+    expect(() => loadProjectConfig(undefined, dir)).toThrow(path);
+  });
+
+  it("throws on an invalid config, naming the file and the key", () => {
+    writeConfig(dir, { failon: "breaking" });
+    const attempt = () => loadProjectConfig(undefined, dir);
+    expect(attempt).toThrow(/failon/);
+    expect(attempt).toThrow(/mcpcontracts\.json/);
+  });
+});
+
+describe("resolveProjectTransport", () => {
+  it("resolves a command server to stdio", () => {
+    const project = loaded({
+      server: { command: "node", args: ["server.js"], env: { A: "b" } },
+    });
+    expect(resolveProjectTransport(project)).toEqual({
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      env: { A: "b" },
+    });
+  });
+
+  it("resolves a url server to streamable-http or sse", () => {
+    const http = loaded({ server: { url: "http://localhost:3000/mcp" } });
+    expect(resolveProjectTransport(http)).toEqual({
+      transport: "streamable-http",
+      url: "http://localhost:3000/mcp",
+      headers: undefined,
+    });
+
+    const sse = loaded({
+      server: { url: "http://localhost:3000/sse", sse: true, headers: { "X-Key": "v" } },
+    });
+    expect(resolveProjectTransport(sse)).toEqual({
+      transport: "sse",
+      url: "http://localhost:3000/sse",
+      headers: { "X-Key": "v" },
+    });
+  });
+
+  it("resolves a config reference relative to the project config", () => {
+    writeFileSync(
+      join(dir, "mcp.json"),
+      JSON.stringify({ mcpServers: { alpha: { command: "node", args: ["a.js"] } } }),
+      "utf-8",
+    );
+    const project = loaded({ server: { config: "./mcp.json", name: "alpha" } });
+    expect(resolveProjectTransport(project)).toEqual({
+      transport: "stdio",
+      command: "node",
+      args: ["a.js"],
+      env: undefined,
+    });
+  });
+
+  it("throws when the config has no server block", () => {
+    const project = loaded({ baseline: "b.mcpc.json" });
+    expect(() => resolveProjectTransport(project)).toThrow(/no "server" block/);
+  });
+});
+
+describe("resolveTransportOrProject", () => {
+  it("uses the project server when no transport flags are given", () => {
+    const project = loaded({ server: { command: "node", args: ["server.js"] } });
+    const transport = resolveTransportOrProject({}, project);
+    expect(transport).toEqual({
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      env: undefined,
+    });
+  });
+
+  it("ignores the project server entirely when a transport flag is given", () => {
+    const project = loaded({ server: { command: "node", args: ["config.js"] } });
+    const transport = resolveTransportOrProject({ command: "deno" }, project);
+    expect(transport).toEqual({
+      transport: "stdio",
+      command: "deno",
+      args: undefined,
+      env: undefined,
+    });
+  });
+
+  it("does not merge partial flags with the project server", () => {
+    const project = loaded({ server: { command: "node", args: ["config.js"] } });
+    expect(() => resolveTransportOrProject({ args: ["other.js"] }, project)).toThrow(
+      /Specify one of/,
+    );
+  });
+
+  it("mentions the config file when it exists without a server block", () => {
+    const project = loaded({ baseline: "b.mcpc.json" });
+    expect(() => resolveTransportOrProject({}, project)).toThrow(/add a "server" block/);
+  });
+
+  it("suggests creating a config when none exists", () => {
+    expect(() => resolveTransportOrProject({}, null)).toThrow(/mcpcontracts\.json/);
+  });
+});
+
+describe("resolveBaselinePath", () => {
+  it("prefers the flag value", () => {
+    const project = loaded({ baseline: "contracts/baseline.mcpc.json" });
+    expect(resolveBaselinePath("flag.mcpc.json", project)).toBe("flag.mcpc.json");
+  });
+
+  it("resolves the config baseline against the config directory", () => {
+    const project = loaded({ baseline: "contracts/baseline.mcpc.json" });
+    expect(resolveBaselinePath(undefined, project)).toBe(
+      resolve(dir, "contracts/baseline.mcpc.json"),
+    );
+  });
+
+  it("keeps an absolute config baseline as-is", () => {
+    const absolute = join(dir, "abs.mcpc.json");
+    const project = loaded({ baseline: absolute });
+    expect(resolveBaselinePath(undefined, project)).toBe(absolute);
+  });
+
+  it("returns undefined when neither source has a baseline", () => {
+    expect(resolveBaselinePath(undefined, null)).toBeUndefined();
+    const project = loaded({ failOn: "warning" });
+    expect(resolveBaselinePath(undefined, project)).toBeUndefined();
+  });
+});

--- a/packages/cli/src/project-config.test.ts
+++ b/packages/cli/src/project-config.test.ts
@@ -110,6 +110,7 @@ describe("resolveProjectTransport", () => {
       command: "node",
       args: ["server.js"],
       env: { A: "b" },
+      cwd: project.dir,
     });
   });
 
@@ -143,6 +144,7 @@ describe("resolveProjectTransport", () => {
       command: "node",
       args: ["a.js"],
       env: undefined,
+      cwd: project.dir,
     });
   });
 
@@ -161,6 +163,7 @@ describe("resolveTransportOrProject", () => {
       command: "node",
       args: ["server.js"],
       env: undefined,
+      cwd: project.dir,
     });
   });
 

--- a/packages/cli/src/project-config.ts
+++ b/packages/cli/src/project-config.ts
@@ -121,6 +121,10 @@ export function resolveProjectPath(project: LoadedProjectConfig, path: string): 
 /**
  * Resolves the project config's server block into a transport.
  *
+ * Stdio servers spawn with the config file's directory as their working
+ * directory, so relative command args (e.g. "node server.js") work no matter
+ * which subdirectory the CLI runs from.
+ *
  * @param project - The loaded project config.
  * @returns The resolved transport configuration.
  */
@@ -135,6 +139,7 @@ export function resolveProjectTransport(project: LoadedProjectConfig): ResolvedT
       command: server.command,
       args: server.args,
       env: server.env,
+      cwd: project.dir,
     };
   }
   if (isProjectServerUrl(server)) {
@@ -144,7 +149,12 @@ export function resolveProjectTransport(project: LoadedProjectConfig): ResolvedT
       headers: server.headers,
     };
   }
-  return readMcpConfig(resolveProjectPath(project, server.config), server.name);
+  const mcpConfigPath = resolveProjectPath(project, server.config);
+  const resolved = readMcpConfig(mcpConfigPath, server.name);
+  if (resolved.transport === "stdio") {
+    resolved.cwd = dirname(mcpConfigPath);
+  }
+  return resolved;
 }
 
 /**

--- a/packages/cli/src/project-config.ts
+++ b/packages/cli/src/project-config.ts
@@ -1,0 +1,198 @@
+/**
+ * mcpcontracts.json discovery, loading, and option resolution.
+ *
+ * The schema and validation live in @mcp-contracts/core; this module handles
+ * the I/O side: finding the file by walking up from the CWD, reading it, and
+ * resolving CLI options with flags > config file > built-in defaults
+ * precedence.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import type { ProjectConfig } from "@mcp-contracts/core";
+import {
+  isProjectServerCommand,
+  isProjectServerUrl,
+  PROJECT_CONFIG_FILENAME,
+  parseProjectConfig,
+} from "@mcp-contracts/core";
+import type { ResolvedTransport } from "./commands/mcp-client.js";
+import { readMcpConfig } from "./mcp-config.js";
+import { extractTransportOptions, hasTransportFlags, resolveTransport } from "./transport.js";
+
+/** A project config together with where it was found. */
+export interface LoadedProjectConfig {
+  /** Absolute path to the config file. */
+  path: string;
+  /** Directory containing the config file; base for its relative paths. */
+  dir: string;
+  /** The validated config contents. */
+  config: ProjectConfig;
+}
+
+/**
+ * Finds the nearest mcpcontracts.json by walking up from a directory.
+ *
+ * @param startDir - Directory to start the search from.
+ * @returns Absolute path to the config file, or null if none exists.
+ */
+export function discoverProjectConfig(startDir: string): string | null {
+  let dir = resolve(startDir);
+  while (true) {
+    const candidate = join(dir, PROJECT_CONFIG_FILENAME);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Loads and validates the project config.
+ *
+ * With an explicit path (--project), the file must exist. Otherwise the file
+ * is discovered by walking up from the CWD, and its absence is not an error.
+ * A file that exists but fails to parse or validate always throws, so typos
+ * are surfaced even when flags would have overridden the config.
+ *
+ * @param explicitPath - Path from the --project option, if given.
+ * @param cwd - Directory to resolve and discover from (defaults to process.cwd()).
+ * @returns The loaded config, or null when no config file exists.
+ */
+export function loadProjectConfig(
+  explicitPath: string | undefined,
+  cwd: string = process.cwd(),
+): LoadedProjectConfig | null {
+  let path: string;
+  if (explicitPath) {
+    path = resolve(cwd, explicitPath);
+    if (!existsSync(path)) {
+      throw new Error(`Project config file "${path}" not found`);
+    }
+  } else {
+    const discovered = discoverProjectConfig(cwd);
+    if (!discovered) {
+      return null;
+    }
+    path = discovered;
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read project config "${path}": ${message}`);
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON in project config "${path}"`);
+  }
+
+  let config: ProjectConfig;
+  try {
+    config = parseProjectConfig(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`${message} (in "${path}")`);
+  }
+
+  return { path, dir: dirname(path), config };
+}
+
+/**
+ * Resolves a possibly-relative path against the config file's directory.
+ *
+ * @param project - The loaded project config.
+ * @param path - Path from the config file.
+ * @returns An absolute path.
+ */
+export function resolveProjectPath(project: LoadedProjectConfig, path: string): string {
+  return isAbsolute(path) ? path : resolve(project.dir, path);
+}
+
+/**
+ * Resolves the project config's server block into a transport.
+ *
+ * @param project - The loaded project config.
+ * @returns The resolved transport configuration.
+ */
+export function resolveProjectTransport(project: LoadedProjectConfig): ResolvedTransport {
+  const server = project.config.server;
+  if (!server) {
+    throw new Error(`Project config "${project.path}" has no "server" block`);
+  }
+  if (isProjectServerCommand(server)) {
+    return {
+      transport: "stdio",
+      command: server.command,
+      args: server.args,
+      env: server.env,
+    };
+  }
+  if (isProjectServerUrl(server)) {
+    return {
+      transport: server.sse ? "sse" : "streamable-http",
+      url: server.url,
+      headers: server.headers,
+    };
+  }
+  return readMcpConfig(resolveProjectPath(project, server.config), server.name);
+}
+
+/**
+ * Resolves the transport from CLI flags or the project config's server block.
+ *
+ * Any transport flag on the command line means the config's server block is
+ * ignored entirely; the two sources are never partially merged.
+ *
+ * @param options - The raw parsed options record from a command action.
+ * @param project - The loaded project config, if any.
+ * @returns The resolved transport configuration.
+ */
+export function resolveTransportOrProject(
+  options: Record<string, unknown>,
+  project: LoadedProjectConfig | null,
+): ResolvedTransport {
+  const flags = extractTransportOptions(options);
+  if (hasTransportFlags(flags)) {
+    return resolveTransport(flags);
+  }
+  if (project?.config.server) {
+    return resolveProjectTransport(project);
+  }
+  const hint = project
+    ? `add a "server" block to "${project.path}"`
+    : `create an ${PROJECT_CONFIG_FILENAME} with a "server" block`;
+  throw new Error(`Specify one of: --command, --url, or --config (or ${hint})`);
+}
+
+/**
+ * Resolves the baseline path from a CLI flag or the project config.
+ *
+ * A relative baseline in the config resolves against the config file's
+ * directory, so commands behave the same from any subdirectory.
+ *
+ * @param flagValue - The --baseline (or --output) value, if given.
+ * @param project - The loaded project config, if any.
+ * @returns The resolved baseline path, or undefined if neither source has one.
+ */
+export function resolveBaselinePath(
+  flagValue: string | undefined,
+  project: LoadedProjectConfig | null,
+): string | undefined {
+  if (flagValue) {
+    return flagValue;
+  }
+  if (project?.config.baseline) {
+    return resolveProjectPath(project, project.config.baseline);
+  }
+  return undefined;
+}

--- a/packages/cli/src/project-config.ts
+++ b/packages/cli/src/project-config.ts
@@ -20,6 +20,9 @@ import type { ResolvedTransport } from "./commands/mcp-client.js";
 import { readMcpConfig } from "./mcp-config.js";
 import { extractTransportOptions, hasTransportFlags, resolveTransport } from "./transport.js";
 
+/** Default baseline path used when neither flags nor config specify one. */
+export const DEFAULT_BASELINE_PATH = "contracts/baseline.mcpc.json";
+
 /** A project config together with where it was found. */
 export interface LoadedProjectConfig {
   /** Absolute path to the config file. */

--- a/packages/cli/src/transport.test.ts
+++ b/packages/cli/src/transport.test.ts
@@ -2,7 +2,13 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { Command } from "commander";
 import { describe, expect, it } from "vitest";
-import { addTransportOptions, parseHeaders, resolveTransport } from "./transport.js";
+import {
+  addTransportOptions,
+  extractTransportOptions,
+  hasTransportFlags,
+  parseHeaders,
+  resolveTransport,
+} from "./transport.js";
 
 describe("resolveTransport", () => {
   it("resolves --command to stdio transport", () => {
@@ -174,5 +180,55 @@ describe("addTransportOptions", () => {
     const cmd = new Command("test");
     const result = addTransportOptions(cmd);
     expect(result).toBe(cmd);
+  });
+});
+
+describe("extractTransportOptions", () => {
+  it("extracts all transport fields from a parsed options record", () => {
+    const options = {
+      command: "node",
+      args: ["server.js"],
+      env: ["A=b"],
+      url: "http://localhost:3000",
+      sse: true,
+      header: ["X: y"],
+      config: "./mcp.json",
+      server: "alpha",
+      baseline: "ignored.mcpc.json",
+    };
+    expect(extractTransportOptions(options)).toEqual({
+      command: "node",
+      args: ["server.js"],
+      env: ["A=b"],
+      url: "http://localhost:3000",
+      sse: true,
+      header: ["X: y"],
+      config: "./mcp.json",
+      server: "alpha",
+    });
+  });
+
+  it("leaves absent fields undefined", () => {
+    const extracted = extractTransportOptions({ severity: "safe" });
+    expect(extracted.command).toBeUndefined();
+    expect(extracted.sse).toBeUndefined();
+  });
+});
+
+describe("hasTransportFlags", () => {
+  it("returns false for empty options", () => {
+    expect(hasTransportFlags(extractTransportOptions({}))).toBe(false);
+    expect(hasTransportFlags(extractTransportOptions({ baseline: "b.mcpc.json" }))).toBe(false);
+  });
+
+  it("returns true when any transport flag is set", () => {
+    expect(hasTransportFlags(extractTransportOptions({ command: "node" }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ url: "http://x" }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ config: "./mcp.json" }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ args: ["a"] }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ env: ["A=b"] }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ sse: true }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ header: ["X: y"] }))).toBe(true);
+    expect(hasTransportFlags(extractTransportOptions({ server: "alpha" }))).toBe(true);
   });
 });

--- a/packages/cli/src/transport.ts
+++ b/packages/cli/src/transport.ts
@@ -89,6 +89,48 @@ export function resolveTransport(options: TransportOptions): ResolvedTransport {
 }
 
 /**
+ * Extracts the transport-related fields from parsed Commander options.
+ *
+ * @param options - The raw parsed options record from a command action.
+ * @returns The typed transport options.
+ */
+export function extractTransportOptions(options: Record<string, unknown>): TransportOptions {
+  return {
+    command: options["command"] as string | undefined,
+    url: options["url"] as string | undefined,
+    config: options["config"] as string | undefined,
+    server: options["server"] as string | undefined,
+    args: options["args"] as string[] | undefined,
+    env: options["env"] as string[] | undefined,
+    sse: options["sse"] === true ? true : undefined,
+    header: options["header"] as string[] | undefined,
+  };
+}
+
+/**
+ * Checks whether any transport flag was passed on the command line.
+ *
+ * Used to decide between CLI flags and the project config's server block —
+ * any transport flag means the config's server block is ignored entirely,
+ * so the two sources are never partially merged.
+ *
+ * @param options - The extracted transport options.
+ * @returns True if at least one transport flag is set.
+ */
+export function hasTransportFlags(options: TransportOptions): boolean {
+  return (
+    options.command !== undefined ||
+    options.url !== undefined ||
+    options.config !== undefined ||
+    options.server !== undefined ||
+    options.args !== undefined ||
+    options.env !== undefined ||
+    options.sse !== undefined ||
+    options.header !== undefined
+  );
+}
+
+/**
  * Adds the standard transport options to a Commander command.
  *
  * Avoids repeating the option calls across commands that need

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,5 +1,20 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import type { Command } from "commander";
+
+/**
+ * Resolves the root program options from a possibly nested subcommand.
+ *
+ * @param cmd - The current Command instance.
+ * @returns The root program's parsed options.
+ */
+export function getRootOpts(cmd: Command): Record<string, unknown> {
+  let current: Command = cmd;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}
 
 /** Output format for CLI commands. */
 export type OutputFormat = "terminal" | "json" | "markdown";

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,6 +1,22 @@
 import { readFileSync, writeFileSync } from "node:fs";
-import type { MCPContractSnapshot } from "@mcp-contracts/core";
+import type { MCPContractSnapshot, Severity } from "@mcp-contracts/core";
 import type { Command } from "commander";
+
+const VALID_SEVERITIES = new Set<string>(["safe", "warning", "breaking"]);
+
+/**
+ * Validates that a string is a valid Severity level.
+ *
+ * @param value - The string to validate.
+ * @param label - Label for the option (used in error messages).
+ * @returns The validated Severity value.
+ */
+export function parseSeverity(value: string, label: string): Severity {
+  if (!VALID_SEVERITIES.has(value)) {
+    throw new Error(`Invalid ${label} value "${value}". Must be one of: safe, warning, breaking`);
+  }
+  return value as Severity;
+}
 
 /**
  * Resolves the root program options from a possibly nested subcommand.

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -19,6 +19,18 @@ export function parseSeverity(value: string, label: string): Severity {
 }
 
 /**
+ * Prints a one-line deprecation notice to stderr.
+ *
+ * @param oldSpelling - The deprecated command spelling (e.g. "mcpdiff ci").
+ * @param newSpelling - The replacement to point users at (e.g. "mcpdiff check").
+ */
+export function printDeprecationNotice(oldSpelling: string, newSpelling: string): void {
+  process.stderr.write(
+    `Warning: '${oldSpelling}' is deprecated and will be removed in a future release; use '${newSpelling}' instead\n`,
+  );
+}
+
+/**
  * Resolves the root program options from a possibly nested subcommand.
  *
  * @param cmd - The current Command instance.

--- a/packages/cli/src/watch-loop.ts
+++ b/packages/cli/src/watch-loop.ts
@@ -1,0 +1,244 @@
+/**
+ * The watch-mode loop: re-capture and re-diff a live server on file changes.
+ *
+ * Shared by `check --watch` and the deprecated `watch` command.
+ */
+
+import { watch } from "node:fs/promises";
+import { resolve } from "node:path";
+import type {
+  DiffReport,
+  MCPContractSnapshot,
+  Severity,
+  WatchConfig,
+  WatchDiffEvent,
+} from "@mcp-contracts/core";
+import {
+  createWatchConfig,
+  createWebhookPayload,
+  DEFAULT_WATCH_IGNORE_PATTERNS,
+  diffSnapshots,
+  formatTerminal,
+  SEVERITY_ORDER,
+} from "@mcp-contracts/core";
+import { captureSnapshot } from "./commands/capture.js";
+import type { ResolvedTransport } from "./commands/mcp-client.js";
+import { readSnapshotFile } from "./utils.js";
+import {
+  clearScreen,
+  formatWatchCycle,
+  formatWatchError,
+  formatWatchHeader,
+} from "./watch-output.js";
+import { sendWebhook } from "./webhook.js";
+
+/** Parameters for running the watch loop. */
+export interface WatchLoopParams {
+  /** How to reach the MCP server. */
+  transport: ResolvedTransport;
+  /** Path to the baseline snapshot file. */
+  baselinePath: string;
+  /** Paths to watch for changes. */
+  watchPaths: string[];
+  /** Debounce interval in milliseconds. */
+  debounceMs: number;
+  /** Minimum severity to display. */
+  minSeverity: Severity;
+  /** Severity threshold for the breaking-changes warning. */
+  failOn: Severity;
+  /** Webhook URL to POST diffs to on each cycle, if any. */
+  webhookUrl: string | undefined;
+  /** Clear the screen between diff cycles. */
+  shouldClear: boolean;
+  /** Suppress non-essential output. */
+  quiet: boolean;
+}
+
+/**
+ * Checks if a file path matches any of the ignore patterns.
+ *
+ * @param filePath - The file path to check.
+ * @param patterns - Glob-like patterns to match against.
+ * @returns True if the path should be ignored.
+ */
+function shouldIgnore(filePath: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    // Simple glob matching: convert ** and * to regex
+    const escaped = pattern
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/\*\*/g, "{{GLOBSTAR}}")
+      .replace(/\*/g, "[^/]*")
+      .replace(/\{\{GLOBSTAR\}\}/g, ".*");
+    const regex = new RegExp(escaped);
+    if (regex.test(filePath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Sends a webhook notification for a diff report if configured.
+ *
+ * @param webhookUrl - The URL to POST to, or undefined to skip.
+ * @param report - The diff report to send.
+ * @param baselinePath - Path to the baseline snapshot file.
+ */
+async function maybeSendWebhook(
+  webhookUrl: string | undefined,
+  report: DiffReport,
+  baselinePath: string,
+): Promise<void> {
+  if (!webhookUrl) return;
+  const payload = createWebhookPayload(report, {
+    trigger: "watch",
+    baselinePath,
+  });
+  const result = await sendWebhook(webhookUrl, payload);
+  if (!result.success) {
+    process.stderr.write(`Warning: Webhook failed: ${result.error}\n`);
+  }
+}
+
+/**
+ * Checks if a diff report contains changes above the fail threshold and warns.
+ *
+ * @param baseline - The baseline snapshot.
+ * @param current - The current snapshot.
+ * @param config - Watch configuration.
+ * @param quiet - Whether to suppress output.
+ */
+function checkFailThreshold(
+  baseline: MCPContractSnapshot,
+  current: MCPContractSnapshot,
+  config: WatchConfig,
+  quiet: boolean,
+): void {
+  const fullReport = diffSnapshots(baseline, current);
+  const failThreshold = SEVERITY_ORDER[config.failOn];
+  const hasFailure = fullReport.changes.some((c) => SEVERITY_ORDER[c.severity] >= failThreshold);
+  if (hasFailure && !quiet) {
+    process.stderr.write("Breaking changes detected!\n");
+  }
+}
+
+/**
+ * Watches for file changes and re-diffs the live server against the baseline
+ * on each change, until interrupted (SIGINT/SIGTERM).
+ *
+ * @param params - The fully resolved watch parameters.
+ */
+export async function runWatchLoop(params: WatchLoopParams): Promise<void> {
+  const { transport, baselinePath, watchPaths, debounceMs, webhookUrl, shouldClear, quiet } =
+    params;
+
+  const config = createWatchConfig({
+    debounceMs,
+    watchPaths,
+    minSeverity: params.minSeverity,
+    failOn: params.failOn,
+  });
+
+  // Print header
+  process.stderr.write(formatWatchHeader(baselinePath, watchPaths, debounceMs));
+
+  // Set up abort controller for graceful shutdown
+  const ac = new AbortController();
+
+  const shutdown = () => {
+    process.stderr.write("\nShutting down watch mode...\n");
+    ac.abort();
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  let cycle = 0;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingPaths: string[] = [];
+
+  /**
+   * Runs a single diff cycle.
+   *
+   * @param triggerPaths - File paths that triggered this cycle.
+   */
+  async function runCycle(triggerPaths: string[]): Promise<void> {
+    cycle++;
+    const start = Date.now();
+
+    let event: WatchDiffEvent;
+
+    try {
+      const baseline = readSnapshotFile(baselinePath);
+      const { snapshot: current } = await captureSnapshot({ transport, quiet: true });
+      const report = diffSnapshots(baseline, current, { minSeverity: config.minSeverity });
+
+      event = {
+        cycle,
+        timestamp: new Date().toISOString(),
+        report,
+        triggerPaths,
+        durationMs: Date.now() - start,
+      };
+
+      if (shouldClear) {
+        process.stdout.write(clearScreen());
+      }
+
+      process.stdout.write(formatWatchCycle(event, formatTerminal));
+
+      await maybeSendWebhook(webhookUrl, report, baselinePath);
+      checkFailThreshold(baseline, current, config, quiet);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      event = {
+        cycle,
+        timestamp: new Date().toISOString(),
+        triggerPaths,
+        durationMs: Date.now() - start,
+        error: message,
+      };
+      process.stderr.write(formatWatchError(event));
+    }
+  }
+
+  // Start watching
+  const resolvedPaths = watchPaths.map((p) => resolve(p));
+  const watchers = resolvedPaths.map((p) => watch(p, { recursive: true, signal: ac.signal }));
+
+  try {
+    // Use Promise.race of all watchers to handle events
+    const watcherPromises = watchers.map(async (watcher) => {
+      for await (const event of watcher) {
+        if (ac.signal.aborted) break;
+        const filename = event.filename ?? "";
+        if (shouldIgnore(filename, [...DEFAULT_WATCH_IGNORE_PATTERNS])) {
+          continue;
+        }
+        pendingPaths.push(filename);
+
+        if (debounceTimer) {
+          clearTimeout(debounceTimer);
+        }
+        debounceTimer = setTimeout(() => {
+          const paths = [...pendingPaths];
+          pendingPaths = [];
+          runCycle(paths);
+        }, config.debounceMs);
+      }
+    });
+
+    await Promise.all(watcherPromises);
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      // Expected on shutdown
+    } else {
+      throw err;
+    }
+  } finally {
+    process.removeListener("SIGINT", shutdown);
+    process.removeListener("SIGTERM", shutdown);
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "tsup": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-contracts/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Snapshot, diff, and classify MCP tool schema changes",
   "type": "module",
   "exports": {

--- a/packages/core/src/diff.test.ts
+++ b/packages/core/src/diff.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { diffSnapshots } from "./diff.js";
+import { createEmptyDiffReport, diffSnapshots } from "./diff.js";
 import type { MCPContractSnapshot } from "./types.js";
 
 function loadFixture(name: string): MCPContractSnapshot {
@@ -271,5 +271,16 @@ describe("diffSnapshots — prompt changes", () => {
     );
     expect(descChange).toHaveLength(1);
     expect(descChange[0]?.severity).toBe("warning");
+  });
+});
+
+describe("createEmptyDiffReport", () => {
+  it("builds a no-changes report without running the diff engine", () => {
+    const v1 = loadFixture("server-v1.mcpc.json");
+    const report = createEmptyDiffReport(v1, v1);
+    expect(report.changes).toHaveLength(0);
+    expect(report.summary).toEqual({ breaking: 0, warning: 0, safe: 0, total: 0 });
+    expect(report.meta.before.serverName).toBe(v1.server.name);
+    expect(report.meta.after.contentHash).toBe(v1.contentHash);
   });
 });

--- a/packages/core/src/diff.ts
+++ b/packages/core/src/diff.ts
@@ -337,6 +337,27 @@ function diffPrompts(before: MCPContractSnapshot, after: MCPContractSnapshot): S
 }
 
 /**
+ * Builds a no-changes diff report without running the diff engine.
+ *
+ * Used as a fast path when the caller already knows the snapshots are
+ * identical (e.g. matching content hashes on honestly generated snapshots).
+ *
+ * @param before - The baseline snapshot.
+ * @param after - The updated snapshot.
+ * @returns A DiffReport with empty changes and zeroed summary counts.
+ */
+export function createEmptyDiffReport(
+  before: MCPContractSnapshot,
+  after: MCPContractSnapshot,
+): DiffReport {
+  return {
+    meta: buildMeta(before, after),
+    summary: buildSummary([]),
+    changes: [],
+  };
+}
+
+/**
  * Compares two MCP Contract Snapshots and returns a detailed diff report.
  *
  * @param before - The baseline snapshot.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,7 @@ export type {
   ServerSnapshotEntry,
   ToolCollision,
 } from "./composition-types.js";
-export { diffSnapshots } from "./diff.js";
+export { createEmptyDiffReport, diffSnapshots } from "./diff.js";
 export type {
   ChangeCategory,
   ChangeType,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,22 @@ export {
   formatGraphTerminal,
 } from "./graph-format.js";
 export { computeContentHash, sortKeys } from "./hash.js";
+export type {
+  ProjectConfig,
+  ProjectServer,
+  ProjectServerCommand,
+  ProjectServerConfigRef,
+  ProjectServerUrl,
+  ProjectWatchSettings,
+} from "./project-config.js";
+export {
+  isProjectServerCommand,
+  isProjectServerConfigRef,
+  isProjectServerUrl,
+  PROJECT_CONFIG_FILENAME,
+  parseProjectConfig,
+  projectConfigSchema,
+} from "./project-config.js";
 export {
   detectKeyAlgorithm,
   parseSignatureFile,

--- a/packages/core/src/project-config.test.ts
+++ b/packages/core/src/project-config.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  isProjectServerCommand,
+  isProjectServerConfigRef,
+  isProjectServerUrl,
+  PROJECT_CONFIG_FILENAME,
+  parseProjectConfig,
+} from "./project-config.js";
+
+describe("parseProjectConfig", () => {
+  it("accepts an empty config", () => {
+    expect(parseProjectConfig({})).toEqual({});
+  });
+
+  it("accepts a full command-based config", () => {
+    const config = parseProjectConfig({
+      server: { command: "node", args: ["dist/index.js"], env: { API_KEY: "secret" } },
+      baseline: "contracts/baseline.mcpc.json",
+      failOn: "breaking",
+      watch: { paths: ["src"], debounce: 500 },
+    });
+    expect(config.baseline).toBe("contracts/baseline.mcpc.json");
+    expect(config.failOn).toBe("breaking");
+    expect(config.watch).toEqual({ paths: ["src"], debounce: 500 });
+    expect(config.server).toEqual({
+      command: "node",
+      args: ["dist/index.js"],
+      env: { API_KEY: "secret" },
+    });
+  });
+
+  it("accepts a url-based server with sse and headers", () => {
+    const config = parseProjectConfig({
+      server: {
+        url: "http://localhost:3000/mcp",
+        sse: true,
+        headers: { Authorization: "Bearer x" },
+      },
+    });
+    expect(config.server).toEqual({
+      url: "http://localhost:3000/mcp",
+      sse: true,
+      headers: { Authorization: "Bearer x" },
+    });
+  });
+
+  it("accepts a config-reference server with a name", () => {
+    const config = parseProjectConfig({
+      server: { config: "./mcp.json", name: "my-server" },
+    });
+    expect(config.server).toEqual({ config: "./mcp.json", name: "my-server" });
+  });
+
+  it("accepts a baseline-only config", () => {
+    expect(parseProjectConfig({ baseline: "contracts/baseline.mcpc.json" })).toEqual({
+      baseline: "contracts/baseline.mcpc.json",
+    });
+  });
+
+  it("rejects non-object data", () => {
+    expect(() => parseProjectConfig("nope")).toThrow(/Invalid project config/);
+    expect(() => parseProjectConfig(null)).toThrow(/Invalid project config/);
+    expect(() => parseProjectConfig([])).toThrow(/Invalid project config/);
+  });
+
+  it("rejects unknown top-level keys, naming the key", () => {
+    expect(() => parseProjectConfig({ failon: "breaking" })).toThrow(/failon/);
+  });
+
+  it("rejects unknown keys inside server", () => {
+    expect(() => parseProjectConfig({ server: { command: "node", cmd: "node" } })).toThrow(/cmd/);
+  });
+
+  it("rejects unknown keys inside watch", () => {
+    expect(() => parseProjectConfig({ watch: { path: ["src"] } })).toThrow(/path/);
+  });
+
+  it("rejects a server with no transport", () => {
+    expect(() => parseProjectConfig({ server: {} })).toThrow(
+      /exactly one of "command", "url", or "config"/,
+    );
+  });
+
+  it("rejects a server with multiple transports", () => {
+    expect(() =>
+      parseProjectConfig({ server: { command: "node", url: "http://localhost:3000" } }),
+    ).toThrow(/exactly one of "command", "url", or "config"/);
+  });
+
+  it("rejects args without command", () => {
+    expect(() =>
+      parseProjectConfig({ server: { url: "http://localhost:3000", args: ["x"] } }),
+    ).toThrow(/"server.args": "args" is only valid with "command"/);
+  });
+
+  it("rejects env without command", () => {
+    expect(() => parseProjectConfig({ server: { config: "./mcp.json", env: { A: "b" } } })).toThrow(
+      /"env" is only valid with "command"/,
+    );
+  });
+
+  it("rejects sse and headers without url", () => {
+    expect(() => parseProjectConfig({ server: { command: "node", sse: true } })).toThrow(
+      /"sse" is only valid with "url"/,
+    );
+    expect(() => parseProjectConfig({ server: { command: "node", headers: {} } })).toThrow(
+      /"headers" is only valid with "url"/,
+    );
+  });
+
+  it("rejects name without config", () => {
+    expect(() => parseProjectConfig({ server: { command: "node", name: "x" } })).toThrow(
+      /"name" is only valid with "config"/,
+    );
+  });
+
+  it("rejects an invalid failOn value", () => {
+    expect(() => parseProjectConfig({ failOn: "fatal" })).toThrow(/failOn/);
+  });
+
+  it("rejects an empty baseline", () => {
+    expect(() => parseProjectConfig({ baseline: "" })).toThrow(/baseline/);
+  });
+
+  it("rejects invalid watch settings", () => {
+    expect(() => parseProjectConfig({ watch: { paths: [] } })).toThrow(/paths/);
+    expect(() => parseProjectConfig({ watch: { debounce: -1 } })).toThrow(/debounce/);
+    expect(() => parseProjectConfig({ watch: { debounce: 1.5 } })).toThrow(/debounce/);
+  });
+
+  it("reports multiple issues in one message", () => {
+    const attempt = () => parseProjectConfig({ failOn: "fatal", baseline: "" });
+    expect(attempt).toThrow(/failOn/);
+    expect(attempt).toThrow(/baseline/);
+  });
+});
+
+describe("ProjectServer type guards", () => {
+  it("discriminate the three variants", () => {
+    const command = { command: "node" };
+    const url = { url: "http://localhost:3000" };
+    const configRef = { config: "./mcp.json" };
+
+    expect(isProjectServerCommand(command)).toBe(true);
+    expect(isProjectServerCommand(url)).toBe(false);
+    expect(isProjectServerUrl(url)).toBe(true);
+    expect(isProjectServerUrl(configRef)).toBe(false);
+    expect(isProjectServerConfigRef(configRef)).toBe(true);
+    expect(isProjectServerConfigRef(command)).toBe(false);
+  });
+});
+
+describe("PROJECT_CONFIG_FILENAME", () => {
+  it("is mcpcontracts.json", () => {
+    expect(PROJECT_CONFIG_FILENAME).toBe("mcpcontracts.json");
+  });
+});

--- a/packages/core/src/project-config.ts
+++ b/packages/core/src/project-config.ts
@@ -1,0 +1,185 @@
+/**
+ * mcpcontracts.json project config: types, schema, and validation.
+ *
+ * The project config file lets repeated CLI invocations (locally and in CI)
+ * omit transport and baseline flags. This module only defines the format and
+ * validates parsed JSON data — file discovery and reading live in the CLI.
+ */
+
+import { z } from "zod/v4";
+import type { Severity } from "./diff-types.js";
+
+/** File name of the project config, discovered by walking up from the CWD. */
+export const PROJECT_CONFIG_FILENAME = "mcpcontracts.json";
+
+/** Server reached by spawning a command over stdio. */
+export interface ProjectServerCommand {
+  /** Executable to run (e.g. "node"). */
+  command: string;
+  /** Arguments for the command. */
+  args?: string[];
+  /** Environment variables for the spawned process. */
+  env?: Record<string, string>;
+}
+
+/** Server reached over streamable-http or SSE. */
+export interface ProjectServerUrl {
+  /** Server URL. */
+  url: string;
+  /** Use SSE transport instead of streamable-http. */
+  sse?: boolean;
+  /** Custom HTTP headers. */
+  headers?: Record<string, string>;
+}
+
+/** Server defined in an external mcp.json config file. */
+export interface ProjectServerConfigRef {
+  /** Path to the mcp.json file, relative to the project config. */
+  config: string;
+  /** Server name to select when the config defines several. */
+  name?: string;
+}
+
+/** One of the three ways to reach the server. */
+export type ProjectServer = ProjectServerCommand | ProjectServerUrl | ProjectServerConfigRef;
+
+/** Watch-mode settings. */
+export interface ProjectWatchSettings {
+  /** Paths to watch for changes. */
+  paths?: string[];
+  /** Debounce interval in milliseconds. */
+  debounce?: number;
+}
+
+/** Parsed mcpcontracts.json contents. */
+export interface ProjectConfig {
+  /** How to reach the MCP server. */
+  server?: ProjectServer;
+  /** Path to the baseline snapshot, relative to the project config. */
+  baseline?: string;
+  /** Severity threshold that triggers exit code 1. */
+  failOn?: Severity;
+  /** Watch-mode settings. */
+  watch?: ProjectWatchSettings;
+}
+
+const serverSchema = z
+  .strictObject({
+    command: z.string().min(1).optional(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    url: z.string().min(1).optional(),
+    sse: z.boolean().optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    config: z.string().min(1).optional(),
+    name: z.string().min(1).optional(),
+  })
+  .superRefine((server, ctx) => {
+    const transports = [server.command, server.url, server.config].filter(
+      (v) => v !== undefined,
+    ).length;
+    if (transports !== 1) {
+      ctx.addIssue({
+        code: "custom",
+        message: 'specify exactly one of "command", "url", or "config"',
+      });
+    }
+    const requires: Array<[unknown, string, string]> = [
+      [server.args, "args", "command"],
+      [server.env, "env", "command"],
+      [server.sse, "sse", "url"],
+      [server.headers, "headers", "url"],
+      [server.name, "name", "config"],
+    ];
+    for (const [value, key, owner] of requires) {
+      if (value !== undefined && server[owner as "command" | "url" | "config"] === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: `"${key}" is only valid with "${owner}"`,
+          path: [key],
+        });
+      }
+    }
+  });
+
+const watchSchema = z.strictObject({
+  paths: z.array(z.string().min(1)).min(1).optional(),
+  debounce: z.number().int().positive().optional(),
+});
+
+const projectConfigSchemaInternal = z.strictObject({
+  server: serverSchema.optional(),
+  baseline: z.string().min(1).optional(),
+  failOn: z.enum(["safe", "warning", "breaking"]).optional(),
+  watch: watchSchema.optional(),
+});
+
+/**
+ * Zod schema for mcpcontracts.json.
+ *
+ * The runtime refinements guarantee the `ProjectServer` union invariant
+ * (exactly one transport key), which the inferred type cannot express.
+ */
+export const projectConfigSchema =
+  projectConfigSchemaInternal as unknown as z.ZodType<ProjectConfig>;
+
+/**
+ * Formats a single zod issue as "path: message".
+ *
+ * @param issue - The zod issue to format.
+ * @returns A human-readable description naming the offending key.
+ */
+function formatIssue(issue: z.core.$ZodIssue): string {
+  if (issue.path.length === 0) {
+    return issue.message;
+  }
+  return `"${issue.path.join(".")}": ${issue.message}`;
+}
+
+/**
+ * Validates parsed JSON data as a project config.
+ *
+ * Unknown keys are an error, so typos like "failon" are caught instead of
+ * silently ignored.
+ *
+ * @param data - Parsed JSON data (e.g. from an mcpcontracts.json file).
+ * @returns The validated ProjectConfig.
+ */
+export function parseProjectConfig(data: unknown): ProjectConfig {
+  const result = projectConfigSchemaInternal.safeParse(data);
+  if (!result.success) {
+    const details = result.error.issues.map(formatIssue).join("; ");
+    throw new Error(`Invalid project config: ${details}`);
+  }
+  return result.data as ProjectConfig;
+}
+
+/**
+ * Narrows a ProjectServer to the stdio command variant.
+ *
+ * @param server - The server block to test.
+ * @returns True if the server is reached by spawning a command.
+ */
+export function isProjectServerCommand(server: ProjectServer): server is ProjectServerCommand {
+  return "command" in server && server.command !== undefined;
+}
+
+/**
+ * Narrows a ProjectServer to the URL variant.
+ *
+ * @param server - The server block to test.
+ * @returns True if the server is reached over HTTP/SSE.
+ */
+export function isProjectServerUrl(server: ProjectServer): server is ProjectServerUrl {
+  return "url" in server && server.url !== undefined;
+}
+
+/**
+ * Narrows a ProjectServer to the mcp.json reference variant.
+ *
+ * @param server - The server block to test.
+ * @returns True if the server is defined in an external mcp.json file.
+ */
+export function isProjectServerConfigRef(server: ProjectServer): server is ProjectServerConfigRef {
+  return "config" in server && server.config !== undefined;
+}

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-contracts/test",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Contract conformance testing for MCP servers",
   "type": "module",
   "exports": {

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -115,6 +115,9 @@ program
   .option("--timeout <ms>", "Global timeout in ms", "120000")
   .option("-o, --output <path>", "Write report to file instead of stdout")
   .action(async (contractPath: string, opts: Record<string, unknown>) => {
+    process.stderr.write(
+      "Note: contract testing is now built into the mcpdiff CLI as 'mcpdiff test'; the mcp-test bin will be removed in a future release\n",
+    );
     try {
       const contract = readContract(contractPath);
 

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -94,7 +94,7 @@ const program = new Command();
 program
   .name("mcp-test")
   .description("Contract conformance testing for MCP servers")
-  .version("0.5.0");
+  .version("0.7.0");
 
 program
   .command("run")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,10 @@ importers:
         version: 4.1.0(@types/node@25.5.0)(vite@7.3.1(@types/node@25.5.0))
 
   packages/core:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^25.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@mcp-contracts/core':
         specifier: workspace:*
         version: link:../core
+      '@mcp-contracts/test':
+        specifier: workspace:^
+        version: link:../test
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)


### PR DESCRIPTION
## Summary

Milestone PR for **v0.7.0 — Developer Experience**: simplify setup and usage of the CLI. Individual features land here via per-issue PRs; this PR merges to `main` once the milestone is complete.

## Included work

- [x] `mcpcontracts.json` project config file (#57, via #63)
- [x] Consolidated `check` / `update` commands, deprecating `ci`, `watch`, `baseline`, `diff --live` (#59, via #64)
- [x] `mcpdiff init` onboarding command (#58, via #67)
- [x] Resolve the `verify` naming collision (#60, via #66)
- [x] Merge `mcp-test` into the CLI as `mcpdiff test` (#61, via #68)
- [x] README two-way pass against the actual CLI surface (#56, via #69)

Closes #56
Closes #57
Closes #58
Closes #59
Closes #60
Closes #61




