### PR TITLE
Resolve the verify naming collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Output:
 
 ## Commands
 
-> Migrating from an older version? `ci`, `watch`, `baseline verify`, `baseline update`, and `diff --live` still work but are deprecated — they are replaced by `check` (with `--watch`) and `update`, and will be removed in a future release.
+> Migrating from an older version? `ci`, `watch`, `baseline verify`, `baseline update`, `diff --live`, and `verify-hash` still work but are deprecated — they are replaced by `check` (with `--watch`), `update`, and `verify` (without `--key`), and will be removed in a future release.
 
 ### `mcpdiff snapshot`
 
@@ -185,28 +185,23 @@ The sign command verifies the content hash before signing — it will refuse to 
 
 ### `mcpdiff verify`
 
-Verifies a snapshot's signature using a public key.
+Verifies the integrity/authenticity of a snapshot file.
 
 ```bash
-# Verify (auto-discovers .mcpc.sig file next to the snapshot)
+# Content hash check only — no keys needed
+mcpdiff verify snapshot.mcpc.json
+
+# Full signature verification (auto-discovers the .mcpc.sig next to the snapshot)
 mcpdiff verify contracts/baseline.mcpc.json --key ./public.pem
 
 # Explicit signature path
 mcpdiff verify snapshot.mcpc.json --key ./public.pem --signature custom/path.mcpc.sig
+
+# JSON output reports which checks ran: ["hash"] or ["hash", "binding", "signature"]
+mcpdiff verify snapshot.mcpc.json --format json
 ```
 
-Performs three checks: content hash integrity, hash binding (signature matches this snapshot), and cryptographic verification. Exit code 0 on success, 1 on failure.
-
-### `mcpdiff verify-hash`
-
-Quick integrity check — recomputes the content hash and compares to the stored value. No keys needed.
-
-```bash
-mcpdiff verify-hash snapshot.mcpc.json
-
-# JSON output
-mcpdiff verify-hash snapshot.mcpc.json --format json
-```
+Without `--key`, only the content hash is recomputed and compared (the output says so, so the weaker check is never mistaken for the stronger one). With `--key`, three checks run: content hash integrity, hash binding (signature matches this snapshot), and cryptographic verification. Exit code 0 on success, 1 on failure.
 
 ### `mcpdiff inspect`
 
@@ -270,7 +265,7 @@ mcpdiff check                  # zero flags locally and in CI
 mcpdiff check --watch          # zero flags in dev
 ```
 
-The config is read by every command that connects to a live server: `check`, `update`, and `snapshot`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`, `verify-hash`) ignore it.
+The config is read by every command that connects to a live server: `check`, `update`, and `snapshot`. Pure file commands (`diff a b`, `inspect`, `sign`, `verify`) ignore it.
 
 **Precedence:** explicit CLI flags > config file > built-in defaults. Passing any transport flag (`--command`, `--url`, `--config`, …) ignores the config's `server` block entirely — the two sources are never partially merged. `failOn` and the `watch` block apply to `check`.
 

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -69,6 +69,7 @@ describe("integration: CLI", () => {
       expect(stdout).not.toMatch(/^ {2}ci\b/m);
       expect(stdout).not.toMatch(/^ {2}watch\b/m);
       expect(stdout).not.toMatch(/^ {2}baseline\b/m);
+      expect(stdout).not.toMatch(/^ {2}verify-hash\b/m);
     });
   });
 
@@ -493,5 +494,57 @@ describe("integration: check and update", () => {
     const diffLive = await runCliIn(projectDir, "diff", "--live", "--format", "json");
     expect(diffLive.exitCode).toBe(0);
     expect(diffLive.stderr).toContain("mcpdiff check");
+  });
+});
+
+describe("integration: verify", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let workDir: string;
+  let snapshotPath: string;
+
+  beforeEach(async () => {
+    workDir = mkdtempSync(join(tmpdir(), "mcpc-verify-"));
+    snapshotPath = join(workDir, "snapshot.mcpc.json");
+    const { exitCode } = await runCliIn(
+      workDir,
+      "snapshot",
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+      "-o",
+      snapshotPath,
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("checks only the content hash without --key and says so", async () => {
+    const json = await runCli("verify", snapshotPath, "--format", "json");
+    expect(json.exitCode).toBe(0);
+    const result = JSON.parse(json.stdout);
+    expect(result.valid).toBe(true);
+    expect(result.checks).toEqual(["hash"]);
+
+    const terminal = await runCli("verify", snapshotPath, "--format", "terminal");
+    expect(terminal.exitCode).toBe(0);
+    expect(terminal.stdout).toContain("Content hash verified");
+    expect(terminal.stderr).toContain("only the content hash was checked");
+  });
+
+  it("verify-hash still works as a deprecated alias", async () => {
+    const { stdout, stderr, exitCode } = await runCli(
+      "verify-hash",
+      snapshotPath,
+      "--format",
+      "json",
+    );
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).valid).toBe(true);
+    expect(stderr).toContain("deprecated");
+    expect(stderr).toContain("mcpdiff verify");
   });
 });

--- a/packages/cli/src/commands/verify-hash.test.ts
+++ b/packages/cli/src/commands/verify-hash.test.ts
@@ -70,6 +70,13 @@ describe("verify-hash command", () => {
     vi.restoreAllMocks();
   });
 
+  it("prints a deprecation notice pointing at verify", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "verify-hash", validPath, "--format", "terminal"]);
+    expect(stderrData).toContain("deprecated");
+    expect(stderrData).toContain("mcpdiff verify");
+  });
+
   it("passes for a valid snapshot (terminal)", async () => {
     const program = createProgram();
     await program.parseAsync(["node", "mcpdiff", "verify-hash", validPath, "--format", "terminal"]);

--- a/packages/cli/src/commands/verify-hash.ts
+++ b/packages/cli/src/commands/verify-hash.ts
@@ -2,7 +2,9 @@ import { verifyContentHash } from "@mcp-contracts/core";
 import { Command } from "commander";
 import {
   CliExitError,
+  getRootOpts,
   handleErrors,
+  printDeprecationNotice,
   readSnapshotFile,
   resolveFormat,
   writeOutput,
@@ -23,6 +25,9 @@ export function createVerifyHashCommand(): Command {
     .action(
       handleErrors(async (snapshotPath: string) => {
         const rootOpts = getRootOpts(cmd);
+        if (rootOpts["quiet"] !== true) {
+          printDeprecationNotice("mcpdiff verify-hash", "mcpdiff verify");
+        }
         const format = resolveFormat(rootOpts["format"] as string | undefined);
         const outputPath = rootOpts["output"] as string | undefined;
 
@@ -46,18 +51,4 @@ export function createVerifyHashCommand(): Command {
     );
 
   return cmd;
-}
-
-/**
- * Resolves the root program options from a deeply nested subcommand.
- *
- * @param cmd - The current Command instance.
- * @returns The root program's parsed options.
- */
-function getRootOpts(cmd: Command): Record<string, unknown> {
-  let current: Command | null = cmd;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
 }

--- a/packages/cli/src/commands/verify.test.ts
+++ b/packages/cli/src/commands/verify.test.ts
@@ -75,6 +75,8 @@ describe("verify command", () => {
     await program.parseAsync([
       "node",
       "mcpdiff",
+      "--format",
+      "terminal",
       "verify",
       validSnapshotPath,
       "--key",
@@ -99,6 +101,8 @@ describe("verify command", () => {
       await program.parseAsync([
         "node",
         "mcpdiff",
+        "--format",
+        "terminal",
         "verify",
         validSnapshotPath,
         "--key",
@@ -151,5 +155,93 @@ describe("verify command", () => {
     }
     expect(exitCode).toBe(2);
     expect(stderrData).toContain("Failed to read key file");
+  });
+});
+
+describe("verify command — hash-only mode (no --key)", () => {
+  let stdoutData: string;
+  let stderrData: string;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    stdoutData = "";
+    stderrData = "";
+    exitCode = undefined;
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutData += String(chunk);
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("verifies the content hash and notes the signature was not checked", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "terminal",
+      "verify",
+      validSnapshotPath,
+    ]);
+    expect(stdoutData).toContain("Content hash verified");
+    expect(stderrData).toContain("only the content hash was checked");
+    expect(stderrData).toContain("--key");
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("exits 1 on a tampered snapshot", async () => {
+    const snapshot = JSON.parse(readFileSync(validSnapshotPath, "utf-8"));
+    snapshot.contentHash =
+      "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    const tamperedPath = join(tmpDir, "tampered.mcpc.json");
+    writeFileSync(tamperedPath, JSON.stringify(snapshot, null, 2));
+
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "--format", "terminal", "verify", tamperedPath]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+    expect(stderrData).toContain("Content hash mismatch");
+  });
+
+  it("reports checks: [hash] in JSON output", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "--format", "json", "verify", validSnapshotPath]);
+    const result = JSON.parse(stdoutData);
+    expect(result.valid).toBe(true);
+    expect(result.checks).toEqual(["hash"]);
+  });
+
+  it("reports checks: [hash, binding, signature] in JSON output with --key", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "verify",
+      validSnapshotPath,
+      "--key",
+      ed25519PublicPath,
+      "--signature",
+      sigPath,
+    ]);
+    const result = JSON.parse(stdoutData);
+    expect(result.valid).toBe(true);
+    expect(result.checks).toEqual(["hash", "binding", "signature"]);
   });
 });

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,56 +1,141 @@
 import { readFileSync } from "node:fs";
-import { parseSignatureFile, verifySignature } from "@mcp-contracts/core";
+import { parseSignatureFile, verifyContentHash, verifySignature } from "@mcp-contracts/core";
 import { Command } from "commander";
-import { CliExitError, handleErrors, readSnapshotFile } from "../utils.js";
+import {
+  CliExitError,
+  getRootOpts,
+  handleErrors,
+  readSnapshotFile,
+  resolveFormat,
+  writeOutput,
+} from "../utils.js";
 import { deriveSignaturePath } from "./sign.js";
+
+/** The checks performed by a verify run, in execution order. */
+const HASH_ONLY_CHECKS = ["hash"] as const;
+const SIGNATURE_CHECKS = ["hash", "binding", "signature"] as const;
+
+/**
+ * Runs the content-hash-only verification (no key given).
+ *
+ * @param snapshotPath - Path to the snapshot file.
+ * @param format - Resolved output format.
+ * @param outputPath - Output file path, or undefined for stdout.
+ */
+function verifyHashOnly(
+  snapshotPath: string,
+  format: string,
+  outputPath: string | undefined,
+): void {
+  const snapshot = readSnapshotFile(snapshotPath);
+  const result = verifyContentHash(snapshot);
+
+  if (format === "json") {
+    const output = { ...result, checks: [...HASH_ONLY_CHECKS] };
+    writeOutput(`${JSON.stringify(output, null, 2)}\n`, outputPath);
+  } else if (result.valid) {
+    writeOutput(`Content hash verified: ${result.actual}\n`, outputPath);
+    process.stderr.write(
+      "Note: only the content hash was checked; pass --key to verify a signature\n",
+    );
+  } else {
+    process.stderr.write(
+      `Content hash mismatch!\n  Expected: ${result.expected}\n  Actual:   ${result.actual}\n`,
+    );
+  }
+
+  if (!result.valid) {
+    throw new CliExitError(1);
+  }
+}
+
+/**
+ * Runs the full signature verification (hash + binding + signature).
+ *
+ * @param snapshotPath - Path to the snapshot file.
+ * @param keyPath - Path to the public key file.
+ * @param signaturePath - Explicit signature path, or undefined to derive it.
+ * @param format - Resolved output format.
+ * @param outputPath - Output file path, or undefined for stdout.
+ */
+function verifyWithKey(
+  snapshotPath: string,
+  keyPath: string,
+  signaturePath: string | undefined,
+  format: string,
+  outputPath: string | undefined,
+): void {
+  const snapshot = readSnapshotFile(snapshotPath);
+
+  let keyPem: string;
+  try {
+    keyPem = readFileSync(keyPath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read key file: ${message}`);
+  }
+
+  const sigPath = signaturePath ?? deriveSignaturePath(snapshotPath);
+
+  let sigJson: string;
+  try {
+    sigJson = readFileSync(sigPath, "utf-8");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read signature file "${sigPath}": ${message}`);
+  }
+
+  const sig = parseSignatureFile(sigJson);
+  const result = verifySignature(snapshot, sig, keyPem);
+
+  if (format === "json") {
+    const output = { ...result, checks: [...SIGNATURE_CHECKS] };
+    writeOutput(`${JSON.stringify(output, null, 2)}\n`, outputPath);
+  } else if (result.valid) {
+    process.stderr.write(`Signature verified: ${sig.algorithm} signature is valid\n`);
+  } else {
+    process.stderr.write(`Signature verification failed: ${result.error}\n`);
+  }
+
+  if (!result.valid) {
+    throw new CliExitError(1);
+  }
+}
 
 /**
  * Creates the `verify` subcommand for the mcpdiff CLI.
  *
- * Verifies a snapshot's detached signature using a public key.
- * Checks content hash integrity, hash binding, and cryptographic signature.
+ * Verifies the integrity/authenticity of a snapshot file. Without --key,
+ * checks the content hash only. With --key, additionally verifies the
+ * detached signature (hash + binding + cryptographic check).
  *
  * @returns A Commander Command instance for the verify subcommand.
  */
 export function createVerifyCommand(): Command {
   const cmd = new Command("verify")
-    .description("Verify a snapshot's signature with a public key")
+    .description("Verify a snapshot's integrity (content hash, plus signature with --key)")
     .argument("<snapshot>", "Path to the snapshot file (.mcpc.json)")
-    .requiredOption("--key <path>", "Path to public key (PEM format, Ed25519 or RSA)")
+    .option("--key <path>", "Path to public key (PEM format, Ed25519 or RSA)")
     .option("--signature <path>", "Path to signature file (default: <snapshot>.mcpc.sig)")
     .action(
       handleErrors(async (snapshotPath: string, options: Record<string, unknown>) => {
-        const snapshot = readSnapshotFile(snapshotPath);
+        const rootOpts = getRootOpts(cmd);
+        const format = resolveFormat(rootOpts["format"] as string | undefined);
+        const outputPath = rootOpts["output"] as string | undefined;
 
-        let keyPem: string;
-        try {
-          keyPem = readFileSync(options["key"] as string, "utf-8");
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          throw new Error(`Failed to read key file: ${message}`);
-        }
-
-        const sigPath =
-          (options["signature"] as string | undefined) ?? deriveSignaturePath(snapshotPath);
-
-        let sigJson: string;
-        try {
-          sigJson = readFileSync(sigPath, "utf-8");
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          throw new Error(`Failed to read signature file "${sigPath}": ${message}`);
-        }
-
-        const sig = parseSignatureFile(sigJson);
-        const result = verifySignature(snapshot, sig, keyPem);
-
-        if (result.valid) {
-          process.stderr.write(`Signature verified: ${sig.algorithm} signature is valid\n`);
+        const keyPath = options["key"] as string | undefined;
+        if (!keyPath) {
+          verifyHashOnly(snapshotPath, format, outputPath);
           return;
         }
 
-        process.stderr.write(`Signature verification failed: ${result.error}\n`);
-        throw new CliExitError(1);
+        verifyWithKey(
+          snapshotPath,
+          keyPath,
+          options["signature"] as string | undefined,
+          format,
+          outputPath,
+        );
       }),
     );
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,7 +48,7 @@ program.addCommand(createInspectCommand());
 program.addCommand(createSignCommand());
 program.addCommand(createSnapshotCommand());
 program.addCommand(createVerifyCommand());
-program.addCommand(createVerifyHashCommand());
+program.addCommand(createVerifyHashCommand(), { hidden: true });
 program.addCommand(createWatchCommand(), { hidden: true });
 
 program.parse();


### PR DESCRIPTION
## Summary

Implements #60: `verify` now means exactly one thing — verify the integrity/authenticity of a snapshot file.

- **`mcpdiff verify <snapshot>`** (no `--key`) — content-hash check only, exit 0/1. Terminal output states that only the hash was checked and that `--key` enables signature verification, so the weaker check is never mistaken for the stronger one.
- **`mcpdiff verify <snapshot> --key pub.pem`** — unchanged behavior: hash + binding + cryptographic signature (`--key` switched from required to optional; everything else identical).
- **`--format json`** now reports which checks ran: `"checks": ["hash"]` vs `["hash", "binding", "signature"]`.
- **`verify-hash`** is a hidden deprecated alias with a stderr notice pointing at `verify`, for removal in the next minor.

With `baseline verify` already absorbed by `check` (#64), the full story is now: **verify = file integrity, check = server conformance.**

## Testing

- Unit tests for the hash-only mode (valid, tampered → exit 1, JSON checks arrays for both modes) and the deprecation notice; existing signature tests unchanged in substance.
- Integration tests: snapshot → verify roundtrip against the fixture server, `verify-hash` alias with notice, hidden from `--help`.
- Full matrix green: 564 tests, typecheck, biome.
- Verified end-to-end against `example-contact-server`, including a real Ed25519 sign → verify roundtrip (`checks: hash,binding,signature`) and a tampered-snapshot exit 1.

Refs #60