### PR TITLE
mcpdiff init onboarding command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, "milestone/**"]
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -19,21 +19,23 @@ MCP servers expose tools, resources, and prompts to AI agents. These interfaces 
 ## Quick Start
 
 ```bash
-# Capture a baseline snapshot of your MCP server
-npx @mcp-contracts/cli update --command "node ./my-server/dist/index.js"
-# → writes contracts/baseline.mcpc.json
+# One-command setup: writes mcpcontracts.json and captures the baseline
+npx @mcp-contracts/cli init --command node --args ./my-server/dist/index.js
 
-# Later, check nothing has changed (locally, in CI, anywhere)
-npx @mcp-contracts/cli check --command "node ./my-server/dist/index.js"
+# From then on — zero flags, locally and in CI
+npx @mcp-contracts/cli check
+```
 
-# Or diff two snapshots manually
+`init` writes a [project config](#project-config-mcpcontractsjson) so every later invocation knows your server and baseline, captures `contracts/baseline.mcpc.json`, and prints the CI snippet to paste into your workflow.
+
+You can also diff two snapshots manually:
+
+```bash
 npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v1.mcpc.json
 # ... make changes ...
 npx @mcp-contracts/cli snapshot --command "node ./my-server/dist/index.js" -o v2.mcpc.json
 npx @mcp-contracts/cli diff v1.mcpc.json v2.mcpc.json
 ```
-
-Tired of repeating `--command`? Put it in a [project config](#project-config-mcpcontractsjson) once and run `mcpdiff check` with zero flags.
 
 Output:
 ```
@@ -117,6 +119,25 @@ mcpdiff graph --config ./mcp.json
 mcpdiff --format mermaid graph --config ./mcp.json
 mcpdiff --format dot graph --config ./mcp.json
 ```
+
+### `mcpdiff init`
+
+One-command onboarding: writes `mcpcontracts.json`, captures the initial baseline, and prints next steps including a copy-pasteable CI workflow.
+
+```bash
+# Non-interactive (also works in scripts/CI)
+mcpdiff init --command node --args dist/index.js
+mcpdiff init --url http://localhost:3000/mcp
+mcpdiff init --config ./mcp.json --server my-server
+
+# Interactive: offers servers from ./mcp.json, or asks for a command/URL
+mcpdiff init
+
+# Overwrite an existing mcpcontracts.json
+mcpdiff init --force --command node --args dist/index.js
+```
+
+Without a TTY, missing information exits with code `2` instead of prompting. Nothing is written unless the initial capture succeeds.
 
 ### `mcpdiff check`
 

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -546,5 +546,70 @@ describe("integration: verify", () => {
     expect(JSON.parse(stdout).valid).toBe(true);
     expect(stderr).toContain("deprecated");
     expect(stderr).toContain("mcpdiff verify");
+  });
+});
+
+describe("integration: init", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "mcpc-init-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("initializes a project non-interactively and check passes", async () => {
+    const init = await runCliIn(projectDir, "init", "--command", "node", "--args", FIXTURE_SERVER);
+    expect(init.exitCode).toBe(0);
+    expect(init.stderr).toContain("Wrote mcpcontracts.json");
+    expect(init.stderr).toContain("mcp-contract.yml");
+    expect(init.stderr).toContain("mcpdiff check");
+
+    const config = JSON.parse(
+      readFileSync(join(projectDir, "mcpcontracts.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(config["baseline"]).toBe("contracts/baseline.mcpc.json");
+    expect(config["failOn"]).toBe("breaking");
+    expect(existsSync(join(projectDir, "contracts", "baseline.mcpc.json"))).toBe(true);
+
+    const check = await runCliIn(projectDir, "check", "--format", "json");
+    expect(check.exitCode).toBe(0);
+    expect(check.stderr).toContain("Contract unchanged");
+  });
+
+  it("exits 2 instead of hanging when non-interactive and underspecified", async () => {
+    const { stderr, exitCode } = await runCliIn(projectDir, "init");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--command");
+  });
+
+  it("refuses to overwrite without --force, then overwrites with it", async () => {
+    const first = await runCliIn(projectDir, "init", "--command", "node", "--args", FIXTURE_SERVER);
+    expect(first.exitCode).toBe(0);
+
+    const second = await runCliIn(
+      projectDir,
+      "init",
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+    );
+    expect(second.exitCode).toBe(2);
+    expect(second.stderr).toContain("--force");
+
+    const forced = await runCliIn(
+      projectDir,
+      "init",
+      "--force",
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+    );
+    expect(forced.exitCode).toBe(0);
   });
 });

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,0 +1,217 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createSnapshot } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { buildServerFromFlags, createInitCommand } from "./init.js";
+
+/** Creates a snapshot matching the mock captureSnapshot output. */
+function makeMockSnapshot() {
+  return createSnapshot({
+    server: {
+      name: "test-server",
+      version: "1.0.0",
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+    },
+    tools: [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    capture: { transport: "stdio", source: "node", tool: "mcpdiff/0.1.0" },
+  });
+}
+
+vi.mock("./capture.js", () => ({
+  captureSnapshot: vi.fn().mockImplementation(async () => ({
+    snapshot: makeMockSnapshot(),
+    serverName: "test-server",
+    serverVersion: "1.0.0",
+  })),
+}));
+
+import { captureSnapshot } from "./capture.js";
+
+const TMP_DIR = resolve(import.meta.dirname, "__tmp_init_test");
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file path")
+    .option("--quiet", "Suppress non-essential output")
+    .option("--verbose", "Show detailed information")
+    .option("--project <path>", "Path to mcpcontracts.json");
+  program.addCommand(createInitCommand());
+  return program;
+}
+
+describe("buildServerFromFlags", () => {
+  it("builds a command block with args and env", () => {
+    expect(buildServerFromFlags({ command: "node", args: ["server.js"], env: ["A=b"] })).toEqual({
+      command: "node",
+      args: ["server.js"],
+      env: { A: "b" },
+    });
+  });
+
+  it("builds a url block with sse and headers", () => {
+    expect(
+      buildServerFromFlags({ url: "http://localhost:3000", sse: true, header: ["X: y"] }),
+    ).toEqual({ url: "http://localhost:3000", sse: true, headers: { X: "y" } });
+  });
+
+  it("builds a config reference block", () => {
+    expect(buildServerFromFlags({ config: "./mcp.json", server: "alpha" })).toEqual({
+      config: "./mcp.json",
+      name: "alpha",
+    });
+  });
+
+  it("rejects zero or multiple transports", () => {
+    expect(() => buildServerFromFlags({ args: ["x"] })).toThrow(/Specify one of/);
+    expect(() => buildServerFromFlags({ command: "node", url: "http://x" })).toThrow(
+      /Specify only one of/,
+    );
+  });
+});
+
+describe("init command", () => {
+  let stderrData: string;
+  let exitCode: number | undefined;
+  let stderrSpy: MockInstance;
+  let exitSpy: MockInstance;
+  let stdoutSpy: MockInstance;
+  let cwdSpy: MockInstance;
+
+  beforeEach(() => {
+    stderrData = "";
+    exitCode = undefined;
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrData += String(chunk);
+      return true;
+    });
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+    mkdirSync(TMP_DIR, { recursive: true });
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(TMP_DIR);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+    cwdSpy.mockRestore();
+    if (existsSync(TMP_DIR)) {
+      rmSync(TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("writes config and baseline, prints next steps with CI snippet", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "init", "--command", "node", "--args", "srv.js"]);
+
+    const config = JSON.parse(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8"));
+    expect(config).toEqual({
+      server: { command: "node", args: ["srv.js"] },
+      baseline: "contracts/baseline.mcpc.json",
+      failOn: "breaking",
+    });
+
+    const baseline = JSON.parse(
+      readFileSync(resolve(TMP_DIR, "contracts/baseline.mcpc.json"), "utf-8"),
+    );
+    expect(baseline.server.name).toBe("test-server");
+    expect(baseline.contentHash).toMatch(/^sha256:/);
+
+    expect(stderrData).toContain("Wrote mcpcontracts.json");
+    expect(stderrData).toContain("1 tools");
+    expect(stderrData).toContain("mcpdiff check");
+    expect(stderrData).toContain("mcp-contract.yml");
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("writes a url server block", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "init", "--url", "http://localhost:3000/mcp"]);
+    const config = JSON.parse(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8"));
+    expect(config.server).toEqual({ url: "http://localhost:3000/mcp" });
+  });
+
+  it("writes a config reference block", async () => {
+    writeFileSync(
+      resolve(TMP_DIR, "mcp.json"),
+      JSON.stringify({ mcpServers: { alpha: { command: "node", args: ["a.js"] } } }),
+      "utf-8",
+    );
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "init",
+      "--config",
+      "./mcp.json",
+      "--server",
+      "alpha",
+    ]);
+    const config = JSON.parse(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8"));
+    expect(config.server).toEqual({ config: "./mcp.json", name: "alpha" });
+  });
+
+  it("refuses to overwrite an existing config without --force", async () => {
+    writeFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "{}", "utf-8");
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "init", "--command", "node"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("--force");
+    expect(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8")).toBe("{}");
+  });
+
+  it("overwrites with --force", async () => {
+    writeFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "{}", "utf-8");
+    const program = createProgram();
+    await program.parseAsync(["node", "mcpdiff", "init", "--command", "node", "--force"]);
+    const config = JSON.parse(readFileSync(resolve(TMP_DIR, "mcpcontracts.json"), "utf-8"));
+    expect(config.server).toEqual({ command: "node" });
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("exits 2 without flags when stdin is not a TTY", async () => {
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "init"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("--command");
+    expect(existsSync(resolve(TMP_DIR, "mcpcontracts.json"))).toBe(false);
+  });
+
+  it("writes nothing when the capture fails", async () => {
+    vi.mocked(captureSnapshot).mockRejectedValueOnce(new Error("connection refused"));
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "init", "--command", "node"]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(existsSync(resolve(TMP_DIR, "mcpcontracts.json"))).toBe(false);
+    expect(existsSync(resolve(TMP_DIR, "contracts"))).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,196 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { createInterface } from "node:readline/promises";
+import type { MCPContractSnapshot, ProjectConfig, ProjectServer } from "@mcp-contracts/core";
+import { PROJECT_CONFIG_FILENAME, parseProjectConfig } from "@mcp-contracts/core";
+import { Command } from "commander";
+import { listConfigServers } from "../mcp-config.js";
+import { DEFAULT_BASELINE_PATH, resolveProjectTransport } from "../project-config.js";
+import type { TransportOptions } from "../transport.js";
+import {
+  addTransportOptions,
+  extractTransportOptions,
+  hasTransportFlags,
+  parseHeaders,
+} from "../transport.js";
+import { getRootOpts, handleErrors, parseEnvPairs } from "../utils.js";
+import { captureSnapshot } from "./capture.js";
+
+/** CI workflow snippet printed as part of the next steps. */
+const CI_SNIPPET = `# .github/workflows/mcp-contract.yml
+name: MCP Contract Check
+on: [pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install -g @mcp-contracts/cli
+      - run: mcpdiff check
+`;
+
+/**
+ * Builds the config file's server block from explicit transport flags.
+ *
+ * @param flags - The extracted transport options.
+ * @returns The server block to write into mcpcontracts.json.
+ */
+export function buildServerFromFlags(flags: TransportOptions): ProjectServer {
+  const transports = [flags.command, flags.url, flags.config].filter((v) => v !== undefined);
+  if (transports.length === 0) {
+    throw new Error("Specify one of: --command, --url, or --config");
+  }
+  if (transports.length > 1) {
+    throw new Error("Specify only one of: --command, --url, or --config");
+  }
+
+  if (flags.config !== undefined) {
+    return {
+      config: flags.config,
+      ...(flags.server !== undefined && { name: flags.server }),
+    };
+  }
+  if (flags.url !== undefined) {
+    return {
+      url: flags.url,
+      ...(flags.sse === true && { sse: true }),
+      ...(flags.header !== undefined && { headers: parseHeaders(flags.header) }),
+    };
+  }
+  return {
+    command: flags.command as string,
+    ...(flags.args !== undefined && { args: flags.args }),
+    ...(flags.env !== undefined && { env: parseEnvPairs(flags.env) }),
+  };
+}
+
+/**
+ * Interactively asks for the server, offering mcp.json entries when present.
+ *
+ * @param cwd - The directory being initialized.
+ * @returns The server block to write into mcpcontracts.json.
+ */
+async function promptForServer(cwd: string): Promise<ProjectServer> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const mcpJsonPath = ["mcp.json", ".mcp.json"].map((f) => join(cwd, f)).find(existsSync);
+    if (mcpJsonPath) {
+      const fileName = basename(mcpJsonPath);
+      const servers = listConfigServers(mcpJsonPath);
+      process.stderr.write(`Found ${fileName} with ${servers.length} server(s):\n`);
+      servers.forEach((s, i) => {
+        process.stderr.write(`  ${i + 1}. ${s.name}\n`);
+      });
+      const answer = (
+        await rl.question(`Use which server? [1-${servers.length}, or "m" to enter manually]: `)
+      ).trim();
+      if (answer.toLowerCase() !== "m") {
+        const index = Number.parseInt(answer, 10);
+        const chosen = servers[index - 1];
+        if (!Number.isInteger(index) || !chosen) {
+          throw new Error(`Invalid selection "${answer}"`);
+        }
+        return { config: `./${fileName}`, name: chosen.name };
+      }
+    }
+
+    const input = (await rl.question('Server command (e.g. "node dist/index.js") or URL: ')).trim();
+    if (!input) {
+      throw new Error("No server specified");
+    }
+    if (/^https?:\/\//.test(input)) {
+      return { url: input };
+    }
+    const [command, ...args] = input.split(/\s+/);
+    return args.length > 0 ? { command: command as string, args } : { command: command as string };
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Prints the post-init summary and next steps, including the CI snippet.
+ *
+ * @param snapshot - The captured baseline snapshot.
+ */
+function printNextSteps(snapshot: MCPContractSnapshot): void {
+  const tools = Object.keys(snapshot.tools).length;
+  const resources = Object.keys(snapshot.resources).length;
+  const prompts = Object.keys(snapshot.prompts).length;
+  const parts = [`${tools} tools`];
+  if (resources > 0) parts.push(`${resources} resources`);
+  if (prompts > 0) parts.push(`${prompts} prompts`);
+
+  process.stderr.write(
+    `✓ Wrote ${PROJECT_CONFIG_FILENAME}\n` +
+      `✓ Wrote ${DEFAULT_BASELINE_PATH} (${parts.join(", ")})\n` +
+      "\nNext steps:\n" +
+      `  1. Commit ${PROJECT_CONFIG_FILENAME} and ${DEFAULT_BASELINE_PATH}\n` +
+      "  2. Run `mcpdiff check` to verify the server against the baseline\n" +
+      "  3. Add contract checking to CI:\n\n" +
+      `${CI_SNIPPET}`,
+  );
+}
+
+/**
+ * Creates the `init` subcommand for the mcpdiff CLI.
+ *
+ * One-command onboarding: writes mcpcontracts.json with the chosen server,
+ * captures the initial baseline, and prints next steps. Fully scriptable via
+ * transport flags; prompts interactively on a TTY when no flags are given.
+ *
+ * @returns A Commander Command instance for the init subcommand.
+ */
+export function createInitCommand(): Command {
+  const cmd = new Command("init").description(
+    "Set up contract checking: write mcpcontracts.json and capture the baseline",
+  );
+
+  addTransportOptions(cmd);
+
+  cmd.option("--force", "Overwrite an existing mcpcontracts.json").action(
+    handleErrors(async (options: Record<string, unknown>) => {
+      const rootOpts = getRootOpts(cmd);
+      const quiet = rootOpts["quiet"] === true;
+      const cwd = process.cwd();
+      const configPath = join(cwd, PROJECT_CONFIG_FILENAME);
+
+      if (existsSync(configPath) && options["force"] !== true) {
+        throw new Error(
+          `"${PROJECT_CONFIG_FILENAME}" already exists in this directory (use --force to overwrite)`,
+        );
+      }
+
+      const flags = extractTransportOptions(options);
+      let server: ProjectServer;
+      if (hasTransportFlags(flags)) {
+        server = buildServerFromFlags(flags);
+      } else if (process.stdin.isTTY === true) {
+        server = await promptForServer(cwd);
+      } else {
+        throw new Error(
+          "No server specified. Pass --command, --url, or --config (interactive prompts require a TTY)",
+        );
+      }
+
+      const config: ProjectConfig = parseProjectConfig({
+        server,
+        baseline: DEFAULT_BASELINE_PATH,
+        failOn: "breaking",
+      });
+
+      // Capture first: nothing is written if the server is unreachable.
+      const transport = resolveProjectTransport({ path: configPath, dir: cwd, config });
+      const { snapshot } = await captureSnapshot({ transport, quiet });
+
+      writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+      const baselinePath = join(cwd, DEFAULT_BASELINE_PATH);
+      mkdirSync(dirname(baselinePath), { recursive: true });
+      writeFileSync(baselinePath, `${JSON.stringify(snapshot, null, 2)}\n`, "utf-8");
+
+      printNextSteps(snapshot);
+    }),
+  );
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { createCheckConflictsCommand } from "./commands/check-conflicts.js";
 import { createCiCommand } from "./commands/ci.js";
 import { createDiffCommand } from "./commands/diff.js";
 import { createGraphCommand } from "./commands/graph.js";
+import { createInitCommand } from "./commands/init.js";
 import { createInspectCommand } from "./commands/inspect.js";
 import { createSignCommand } from "./commands/sign.js";
 import { createSnapshotCommand } from "./commands/snapshot.js";
@@ -37,6 +38,7 @@ program
     "Path to mcpcontracts.json (default: discovered by walking up from the CWD)",
   );
 
+program.addCommand(createInitCommand());
 program.addCommand(createCheckCommand());
 program.addCommand(createUpdateCommand());
 program.addCommand(createBaselineCommand(), { hidden: true });


### PR DESCRIPTION
## Summary

Implements #58: one-command setup, shrinking onboarding to `init` + `check`.

```
npx @mcp-contracts/cli init --command node --args dist/index.js
# → wrote mcpcontracts.json
# → wrote contracts/baseline.mcpc.json (12 tools, 2 resources)
# → next steps incl. copy-pasteable CI workflow YAML
```

- **Server detection:** with transport flags (`--command`/`--args`/`--url`/`--sse`/`--header`/`--config`/`--server`/`--env`), init is fully scriptable. On a TTY without flags, it offers the entries from `./mcp.json` / `./.mcp.json` as numbered choices or accepts a manual command/URL. Non-TTY and underspecified → exit `2` with a message instead of hanging on a prompt.
- **Writes `mcpcontracts.json`** (validated through the core schema before writing) with the chosen server, `baseline: contracts/baseline.mcpc.json`, and `failOn: breaking`; refuses to overwrite an existing config unless `--force` is given.
- **Captures the initial baseline** — and captures *first*, so nothing is written if the server is unreachable.
- **Prints next steps** with the actual GitHub Actions YAML snippet (`mcpdiff check`, zero flags, relying on the committed config).
- README quick start rewritten around `init` + `check`, with a new `init` command section.

## Testing

- 11 unit tests (flag→server-block building for all three transport shapes, force/overwrite, non-TTY exit 2, no-write-on-capture-failure)
- 3 `execa` integration tests covering the non-interactive path end-to-end against a fixture stdio server: init → zero-flag `check`, underspecified non-TTY exit 2, `--force` roundtrip
- Full matrix green: 578 tests, typecheck, biome
- Verified end-to-end against `example-contact-server`: `init --config ./mcp.json --server contacts` → zero-flag `check`, and `init --url` against its (newly fixed) HTTP mode

Refs #58