### PR TITLE
Merge mcp-test into the CLI as mcpdiff test

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ Output:
 
 > Migrating from an older version? `ci`, `watch`, `baseline verify`, `baseline update`, `diff --live`, and `verify-hash` still work but are deprecated — they are replaced by `check` (with `--watch`), `update`, and `verify` (without `--key`), and will be removed in a future release.
 
+### `mcpdiff test`
+
+Runs the contract test suite from `@mcp-contracts/test` against a live server: schema conformance (every tool in the contract exists with a matching schema) plus boundary input tests.
+
+```bash
+# With a project config, zero arguments
+mcpdiff test
+
+# Explicit contract and transport
+mcpdiff test contract.mcpc.json --command node --args server.js
+mcpdiff test contract.mcpc.json --url http://localhost:3000/mcp --allow-extra-tools
+
+# Tune the suite
+mcpdiff test --no-boundary --skip-tools delete_contact --timeout 60000
+```
+
+**Exit codes:** `0` = all pass, `1` = failures, `2` = error. The standalone `mcp-test` bin still works but points here; the `@mcp-contracts/test` package remains the library for vitest integration.
+
 ### `mcpdiff snapshot`
 
 Connects to an MCP server and captures its complete tool/resource/prompt interface as a `.mcpc.json` file.
@@ -365,6 +383,7 @@ The `check` command auto-detects the CI environment and selects the right output
 |---------|-------------|
 | [`@mcp-contracts/core`](./packages/core) | Snapshot types, diff engine, classification logic |
 | [`@mcp-contracts/cli`](./packages/cli) | The `mcpdiff` CLI tool |
+| [`@mcp-contracts/test`](./packages/test) | Contract testing library: conformance + boundary runner, vitest matchers |
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@mcp-contracts/core": "workspace:*",
+    "@mcp-contracts/test": "workspace:^",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "cli-table3": "^0.6.0",
     "commander": "^14.0.3"

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -613,3 +613,55 @@ describe("integration: init", () => {
     expect(forced.exitCode).toBe(0);
   });
 });
+
+describe("integration: test command", () => {
+  const FIXTURE_SERVER = resolve(import.meta.dirname, "fixtures/fixture-server.mjs");
+  let projectDir: string;
+
+  beforeEach(async () => {
+    projectDir = mkdtempSync(join(tmpdir(), "mcpc-test-cmd-"));
+    const init = await runCliIn(projectDir, "init", "--command", "node", "--args", FIXTURE_SERVER);
+    expect(init.exitCode).toBe(0);
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("runs the contract test suite with zero arguments via the project config", async () => {
+    const { stdout, exitCode } = await runCliIn(projectDir, "test", "--format", "json");
+    expect(exitCode).toBe(0);
+    const report = JSON.parse(stdout);
+    expect(report.summary.failed).toBe(0);
+    expect(report.summary.errors).toBe(0);
+    expect(report.summary.passed).toBeGreaterThan(0);
+  });
+
+  it("exits 1 when the live server does not conform to the contract", async () => {
+    const baselinePath = join(projectDir, "contracts", "baseline.mcpc.json");
+    const baseline = JSON.parse(readFileSync(baselinePath, "utf-8"));
+    baseline.tools.echo.description = "A different description than the server reports";
+    writeFileSync(baselinePath, JSON.stringify(baseline, null, 2), "utf-8");
+
+    const { stdout, exitCode } = await runCliIn(projectDir, "test", "--format", "json");
+    expect(exitCode).toBe(1);
+    const report = JSON.parse(stdout);
+    expect(report.summary.failed).toBeGreaterThan(0);
+  });
+
+  it("supports explicit contract path and transport flags", async () => {
+    const { exitCode } = await runCliIn(
+      projectDir,
+      "test",
+      join(projectDir, "contracts", "baseline.mcpc.json"),
+      "--command",
+      "node",
+      "--args",
+      FIXTURE_SERVER,
+      "--no-boundary",
+      "--format",
+      "json",
+    );
+    expect(exitCode).toBe(0);
+  });
+});

--- a/packages/cli/src/commands/test.test.ts
+++ b/packages/cli/src/commands/test.test.ts
@@ -1,0 +1,253 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createSnapshot } from "@mcp-contracts/core";
+import type { TestReport } from "@mcp-contracts/test";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { createTestCommand } from "./test.js";
+
+vi.mock("@mcp-contracts/test", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcp-contracts/test")>();
+  return { ...actual, runContractTests: vi.fn() };
+});
+
+import { runContractTests } from "@mcp-contracts/test";
+
+const TMP_DIR = resolve(import.meta.dirname, "__tmp_test_cmd_test");
+
+function makeReport(overrides?: Partial<TestReport["summary"]>): TestReport {
+  return {
+    meta: {
+      contractPath: "contract.mcpc.json",
+      serverName: "test-server",
+      serverVersion: "1.0.0",
+      runAt: new Date().toISOString(),
+      tool: "mcp-test",
+    },
+    summary: {
+      total: 3,
+      passed: 3,
+      failed: 0,
+      skipped: 0,
+      errors: 0,
+      durationMs: 12,
+      ...overrides,
+    },
+    results: [],
+  };
+}
+
+function writeContract(): string {
+  const snapshot = createSnapshot({
+    server: {
+      name: "test-server",
+      version: "1.0.0",
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+    },
+    tools: [
+      { name: "test_tool", description: "A tool", inputSchema: { type: "object", properties: {} } },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    capture: { transport: "stdio", source: "node", tool: "mcpdiff/0.1.0" },
+  });
+  const path = resolve(TMP_DIR, "contract.mcpc.json");
+  writeFileSync(path, JSON.stringify(snapshot, null, 2), "utf-8");
+  return path;
+}
+
+function createProgram(): Command {
+  const program = new Command();
+  program
+    .option("--format <format>", "Output format")
+    .option("--no-color", "Disable colored output")
+    .option("-o, --output <path>", "Output file path")
+    .option("--quiet", "Suppress non-essential output")
+    .option("--verbose", "Show detailed information")
+    .option("--project <path>", "Path to mcpcontracts.json");
+  program.addCommand(createTestCommand());
+  return program;
+}
+
+describe("test command", () => {
+  let stdoutData: string;
+  let stderrData: string;
+  let exitCode: number | undefined;
+  let spies: MockInstance[];
+
+  beforeEach(() => {
+    stdoutData = "";
+    stderrData = "";
+    exitCode = undefined;
+    spies = [
+      vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+        stdoutData += String(chunk);
+        return true;
+      }),
+      vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+        stderrData += String(chunk);
+        return true;
+      }),
+      vi.spyOn(process, "exit").mockImplementation((code) => {
+        exitCode = code as number;
+        throw new Error(`process.exit(${code})`);
+      }),
+    ];
+    mkdirSync(TMP_DIR, { recursive: true });
+    vi.mocked(runContractTests).mockClear();
+    vi.mocked(runContractTests).mockResolvedValue(makeReport());
+  });
+
+  afterEach(() => {
+    for (const spy of spies) spy.mockRestore();
+    if (existsSync(TMP_DIR)) {
+      rmSync(TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("registers with the mcp-test run flag surface plus transport options", () => {
+    const program = createProgram();
+    const testCmd = program.commands.find((c) => c.name() === "test");
+    const optionNames = testCmd?.options.map((o) => o.long) ?? [];
+    for (const opt of [
+      "--no-conformance",
+      "--no-boundary",
+      "--allow-extra-tools",
+      "--ignore-descriptions",
+      "--skip-tools",
+      "--timeout",
+      "--command",
+      "--args",
+      "--url",
+      "--sse",
+      "--header",
+      "--config",
+      "--server",
+      "--env",
+    ]) {
+      expect(optionNames).toContain(opt);
+    }
+  });
+
+  it("runs the suite and exits 0 when everything passes", async () => {
+    const contractPath = writeContract();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "test",
+      contractPath,
+      "--command",
+      "node",
+      "--args",
+      "srv.js",
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    const report = JSON.parse(stdoutData);
+    expect(report.summary.passed).toBe(3);
+
+    const runOptions = vi.mocked(runContractTests).mock.calls[0]?.[0];
+    expect(runOptions?.server).toMatchObject({
+      transport: "stdio",
+      command: "node",
+      args: ["srv.js"],
+    });
+    expect(runOptions?.contractPath).toBe(contractPath);
+    expect(runOptions?.conformance).toEqual({
+      allowExtraTools: false,
+      ignoreDescriptions: false,
+      skipTools: undefined,
+    });
+    expect(runOptions?.boundary).toEqual({ skipTools: undefined });
+    expect(runOptions?.timeoutMs).toBe(120000);
+  });
+
+  it("exits 1 on failures", async () => {
+    vi.mocked(runContractTests).mockResolvedValue(makeReport({ failed: 1, passed: 2 }));
+    const contractPath = writeContract();
+    const program = createProgram();
+    try {
+      await program.parseAsync([
+        "node",
+        "mcpdiff",
+        "--format",
+        "json",
+        "test",
+        contractPath,
+        "--command",
+        "node",
+      ]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(1);
+  });
+
+  it("passes through --no-conformance, --allow-extra-tools, and --skip-tools", async () => {
+    const contractPath = writeContract();
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "test",
+      contractPath,
+      "--command",
+      "node",
+      "--no-conformance",
+      "--skip-tools",
+      "alpha",
+      "beta",
+      "--timeout",
+      "5000",
+    ]);
+    const runOptions = vi.mocked(runContractTests).mock.calls[0]?.[0];
+    expect(runOptions?.conformance).toBe(false);
+    expect(runOptions?.boundary).toEqual({ skipTools: ["alpha", "beta"] });
+    expect(runOptions?.timeoutMs).toBe(5000);
+  });
+
+  it("resolves contract and server from the project config with no arguments", async () => {
+    writeContract();
+    writeFileSync(
+      resolve(TMP_DIR, "mcpcontracts.json"),
+      JSON.stringify({
+        server: { command: "node", args: ["srv.js"] },
+        baseline: "contract.mcpc.json",
+      }),
+      "utf-8",
+    );
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "mcpdiff",
+      "--format",
+      "json",
+      "--project",
+      resolve(TMP_DIR, "mcpcontracts.json"),
+      "test",
+    ]);
+    expect(exitCode).toBeUndefined();
+    const runOptions = vi.mocked(runContractTests).mock.calls[0]?.[0];
+    expect(runOptions?.contractPath).toBe(resolve(TMP_DIR, "contract.mcpc.json"));
+    expect(runOptions?.server).toMatchObject({ transport: "stdio", command: "node" });
+  });
+
+  it("errors with exit 2 when no transport is available", async () => {
+    const contractPath = writeContract();
+    const program = createProgram();
+    try {
+      await program.parseAsync(["node", "mcpdiff", "test", contractPath]);
+    } catch {
+      // expected process.exit
+    }
+    expect(exitCode).toBe(2);
+    expect(stderrData).toContain("Specify one of");
+  });
+});

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,0 +1,128 @@
+import type { TestReport, TestRunOptions, TestServerConfig } from "@mcp-contracts/test";
+import {
+  formatTestJson,
+  formatTestMarkdown,
+  formatTestTerminal,
+  runContractTests,
+} from "@mcp-contracts/test";
+import { Command } from "commander";
+import {
+  DEFAULT_BASELINE_PATH,
+  loadProjectConfig,
+  resolveBaselinePath,
+  resolveTransportOrProject,
+} from "../project-config.js";
+import { addTransportOptions } from "../transport.js";
+import {
+  CliExitError,
+  getRootOpts,
+  handleErrors,
+  type OutputFormat,
+  readSnapshotFile,
+  resolveFormat,
+  writeOutput,
+} from "../utils.js";
+import type { ResolvedTransport } from "./mcp-client.js";
+
+/**
+ * Maps a resolved transport to the test runner's server config.
+ *
+ * @param transport - The resolved transport from flags or project config.
+ * @returns The equivalent TestServerConfig.
+ */
+function toTestServerConfig(transport: ResolvedTransport): TestServerConfig {
+  return {
+    transport: transport.transport,
+    command: transport.command,
+    args: transport.args,
+    env: transport.env,
+    url: transport.url,
+    headers: transport.headers,
+    timeoutMs: 30_000,
+  };
+}
+
+/**
+ * Formats a test report in the requested output format.
+ *
+ * @param report - The test report to format.
+ * @param format - The output format.
+ * @returns The formatted report string.
+ */
+function formatTestReport(report: TestReport, format: OutputFormat): string {
+  if (format === "json") {
+    return formatTestJson(report);
+  }
+  if (format === "markdown") {
+    return formatTestMarkdown(report);
+  }
+  return formatTestTerminal(report);
+}
+
+/**
+ * Creates the `test` subcommand for the mcpdiff CLI.
+ *
+ * Runs the contract test suite (schema conformance + boundary inputs) from
+ * @mcp-contracts/test against a live server. With an mcpcontracts.json
+ * present, `mcpdiff test` with no arguments tests the configured baseline
+ * against the configured server.
+ *
+ * @returns A Commander Command instance for the test subcommand.
+ */
+export function createTestCommand(): Command {
+  const cmd = new Command("test")
+    .description("Run contract conformance and boundary tests against a live server")
+    .argument("[contract]", `Path to the contract file (default: "${DEFAULT_BASELINE_PATH}")`);
+
+  addTransportOptions(cmd);
+
+  cmd
+    .option("--no-conformance", "Skip schema conformance tests")
+    .option("--no-boundary", "Skip boundary input tests")
+    .option("--allow-extra-tools", "Allow tools not in the contract")
+    .option("--ignore-descriptions", "Ignore description differences")
+    .option("--skip-tools <names...>", "Skip specific tools")
+    .option("--timeout <ms>", "Global timeout in ms", "120000")
+    .action(
+      handleErrors(async (contractArg: string | undefined, options: Record<string, unknown>) => {
+        const rootOpts = getRootOpts(cmd);
+        const project = loadProjectConfig(rootOpts["project"] as string | undefined);
+
+        const contractPath =
+          contractArg ?? resolveBaselinePath(undefined, project) ?? DEFAULT_BASELINE_PATH;
+        const contract = readSnapshotFile(contractPath);
+
+        const transport = resolveTransportOrProject(options, project);
+        const skipTools = options["skipTools"] as string[] | undefined;
+
+        const runOptions: TestRunOptions = {
+          contract,
+          contractPath,
+          server: toTestServerConfig(transport),
+          conformance:
+            options["conformance"] === false
+              ? false
+              : {
+                  allowExtraTools: options["allowExtraTools"] === true,
+                  ignoreDescriptions: options["ignoreDescriptions"] === true,
+                  skipTools,
+                },
+          boundary: options["boundary"] === false ? false : { skipTools },
+          timeoutMs: Number(options["timeout"]),
+        };
+
+        const report = await runContractTests(runOptions);
+
+        const format = resolveFormat(rootOpts["format"] as string | undefined);
+        const output = formatTestReport(report, format);
+        writeOutput(`${output}\n`, rootOpts["output"] as string | undefined);
+
+        // Exit codes: 0 = all pass, 1 = failures, 2 = tool error
+        if (report.summary.failed > 0 || report.summary.errors > 0) {
+          throw new CliExitError(1);
+        }
+      }),
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { createInitCommand } from "./commands/init.js";
 import { createInspectCommand } from "./commands/inspect.js";
 import { createSignCommand } from "./commands/sign.js";
 import { createSnapshotCommand } from "./commands/snapshot.js";
+import { createTestCommand } from "./commands/test.js";
 import { createUpdateCommand } from "./commands/update.js";
 import { createVerifyCommand } from "./commands/verify.js";
 import { createVerifyHashCommand } from "./commands/verify-hash.js";
@@ -41,6 +42,7 @@ program
 program.addCommand(createInitCommand());
 program.addCommand(createCheckCommand());
 program.addCommand(createUpdateCommand());
+program.addCommand(createTestCommand());
 program.addCommand(createBaselineCommand(), { hidden: true });
 program.addCommand(createCheckConflictsCommand());
 program.addCommand(createCiCommand(), { hidden: true });

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -115,6 +115,9 @@ program
   .option("--timeout <ms>", "Global timeout in ms", "120000")
   .option("-o, --output <path>", "Write report to file instead of stdout")
   .action(async (contractPath: string, opts: Record<string, unknown>) => {
+    process.stderr.write(
+      "Note: contract testing is now built into the mcpdiff CLI as 'mcpdiff test'; the mcp-test bin will be removed in a future release\n",
+    );
     try {
       const contract = readContract(contractPath);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@mcp-contracts/core':
         specifier: workspace:*
         version: link:../core
+      '@mcp-contracts/test':
+        specifier: workspace:^
+        version: link:../test
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)


### PR DESCRIPTION
## Summary

Implements #61: contract *checking* and contract *testing* now ship from one CLI. `mcpdiff test` runs the conformance + boundary suite from `@mcp-contracts/test`:

```bash
mcpdiff test                                              # zero args via mcpcontracts.json
mcpdiff test contract.mcpc.json --command node --args server.js
mcpdiff test contract.mcpc.json --url http://localhost:3000/mcp --allow-extra-tools
```

- **Flag surface mirrors `mcp-test run`:** `--no-conformance`, `--no-boundary`, `--allow-extra-tools`, `--ignore-descriptions`, `--skip-tools`, `--timeout`, plus the shared transport options and the global `--format`/`-o`. Exit codes unchanged (0 pass / 1 failures / 2 error).
- **Project config aware:** with `mcpcontracts.json` present, `mcpdiff test` with no arguments tests the configured baseline against the configured server.
- **Dependency direction:** `cli → test → core`, no cycle — the CLI consumes the runner/formatters as a library and reuses its own shared transport-option helper; the test package's runner, matchers, and vitest integration are untouched.
- **`mcp-test` bin stays published**, printing a one-line pointer at `mcpdiff test`; removal planned for a future release per the migration plan.
- README documents `mcpdiff test` alongside the other commands, and the packages table now lists all three published packages.

## Testing

- 6 unit tests (flag surface, option passthrough, exit codes, zero-arg project-config resolution, no-transport error)
- 3 `execa` integration tests against the fixture stdio server: zero-arg run via project config, non-conforming server → exit 1, explicit contract + flags
- Full matrix green: 587 tests, typecheck, biome
- Verified end-to-end against `example-contact-server`: zero-arg `mcpdiff test` (57/57 pass), mismatched contract → exit 1, and the `mcp-test` bin pointer notice

Refs #61