### PR TITLE
Publish GitHub releases from the pipeline

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_conventional_commits: true
+          draft: false


### PR DESCRIPTION
The generate-release-notes action defaults to `draft: true`, so every release since v0.6.0 was generated but never published (v0.6.0–v0.7.1 sat as drafts; now published manually). Setting `draft: false` so tagging a version publishes the GitHub release end-to-end.