### PR TITLE
chore: bump generate-release-notes to v0.4.1

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -13,7 +13,7 @@ jobs:
   notes:
     runs-on: ubuntu-latest
     steps:
-      - uses: lukekania/generate-release-notes@v0.3.1
+      - uses: lukekania/generate-release-notes@v0.4.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_conventional_commits: true


### PR DESCRIPTION
Updates the release-notes workflow to use lukekania/generate-release-notes@v0.4.1.