### PR TITLE
Release 0.7.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-contracts/cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "CLI tool for capturing and diffing MCP tool schemas",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -77,7 +77,7 @@ describe("integration: CLI", () => {
     it("exits 0 and prints version", async () => {
       const { stdout, exitCode } = await runCli("--version");
       expect(exitCode).toBe(0);
-      expect(stdout.trim()).toBe("0.7.1");
+      expect(stdout.trim()).toBe("0.7.2");
     });
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,7 +28,7 @@ const program = new Command();
 program
   .name("mcpdiff")
   .description("Capture, diff, and inspect MCP server tool schemas")
-  .version("0.7.1")
+  .version("0.7.2")
   .option("--format <format>", "Output format: terminal | json | markdown")
   .option("--no-color", "Disable colored output")
   .option("-o, --output <path>", "Output file path")

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-contracts/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Snapshot, diff, and classify MCP tool schema changes",
   "type": "module",
   "exports": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-contracts/test",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Contract conformance testing for MCP servers",
   "type": "module",
   "exports": {

--- a/packages/test/src/cli.ts
+++ b/packages/test/src/cli.ts
@@ -94,7 +94,7 @@ const program = new Command();
 program
   .name("mcp-test")
   .description("Contract conformance testing for MCP servers")
-  .version("0.7.1");
+  .version("0.7.2");
 
 program
   .command("run")


### PR DESCRIPTION
Patch release: dependency and security updates only, no functional changes.

- All Dependabot security alerts resolved (58 → 1; the remaining one is a low-severity, dev-only esbuild advisory blocked upstream by tsup's `esbuild@^0.27.0` pin)
- MCP SDK bumped to 1.30.x line, transitive hono/fast-uri/vite/rollup advisories cleared in lockfiles
- biome, @types/node, postcss dev-dependency bumps